### PR TITLE
Fixes #39406 - Add curl retries for ansible callback

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_service.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_service.erb
@@ -7,6 +7,7 @@ description: |
   The content of a systemd service for running Ansible Tower / AWX callback script one-time.
   Used in the ansible_provisioning_callback snippet for systemd enabled systems.
 -%>
+<%- awx_host = parse_url(host_param('ansible_tower_api_url')).hostname.to_s -%>
 [Unit]
 Description=Provisioning callback to Ansible Tower
 Wants=network-online.target
@@ -14,10 +15,20 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+TimeoutStartSec=360s
+<% if awx_host.present? -%>
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts <%= awx_host %>; do sleep 2; done'
+<% end -%>
 <% if host_param('ansible_extra_vars') -%>
-ExecStart=/usr/bin/curl -k -s -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%=host_param('ansible_extra_vars') %>}' <%= host_param('ansible_tower_api_url') %>/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%= host_param('ansible_extra_vars') %>}' <%= host_param('ansible_tower_api_url') %>/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
 <% else -%>
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" <%= host_param('ansible_tower_api_url') -%>/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" <%= host_param('ansible_tower_api_url') -%>/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
 <% end -%>
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -121,7 +121,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -121,7 +121,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -311,7 +311,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -407,7 +407,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -311,7 +311,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -311,7 +311,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -311,7 +311,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
@@ -193,7 +193,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -193,7 +193,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
@@ -310,7 +310,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -309,7 +309,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -310,7 +310,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/ansible_tower_callback_service.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/ansible_tower_callback_service.host4dhcp.snap.txt
@@ -5,7 +5,15 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
+TimeoutStartSec=360s
+# Wait until the Ansible Tower / AWX host name can be resolved before running curl.
+# Right after boot, DNS may not be usable yet (e.g. the network path is still
+# converging), which would make curl fail immediately with exit 6. curl's own retry
+# is not relied on for this: whether it retries exit 6 varies by version (curl 7.29
+# on EL7 does not, and --retry-all-errors is not available there), so we wait here
+# to handle it consistently across curl versions.
+ExecStartPre=-/usr/bin/timeout 60 /bin/sh -c 'until getent hosts host.example.com; do sleep 2; done'
+ExecStart=/usr/bin/curl -k -sS -f --connect-timeout 10 --max-time 30 --retry 7 --retry-delay 5 --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]


### PR DESCRIPTION
## Summary

Fixes `ansible-callback.service` failing on first boot when DNS resolution is not yet available (curl exits with code 6, `Could not resolve host`), causing the callback to Tower/AWX to be lost. Right after boot the network path may not be usable yet (for example while it is still converging), so a single curl attempt fails immediately.

Relying on curl's own retry is not sufficient here: whether curl retries exit 6 depends on the curl version (curl 7.29 on EL7 does not), and `--retry-all-errors` is not available on curl 7.29. To handle this consistently across curl versions, an `ExecStartPre` waits for DNS resolution before curl runs, preventing exit 6 at its root.

## Changes

- Add `ExecStartPre` that waits until the target host resolves via `getent hosts` (up to 60s, bounded with `timeout`). This is the primary fix for exit 6, and it does not depend on the curl version.
- Extract the target host from ansible_tower_api_url using the parse_url helper
(URI.hostname), which handles IPv4, IPv6 literals (unwrapping the brackets), and ports.
- Add `--connect-timeout 10` and `--max-time 30` to bound each curl attempt (max-time prevents a hung response from consuming the whole start timeout and blocking retries).
- Add `--retry 7 --retry-delay 5` for transient errors after DNS is available.
- Add `-f` (HTTP 4xx/5xx exit non-zero) and `-S` (log errors).
- Set `TimeoutStartSec=360s` to accommodate the ExecStartPre wait (up to 60s) plus the ExecStart worst case (`8 × 30 + 7 × 5 = 275s`), about 335s total.
- `--retry-all-errors` is not used, since it is unavailable on curl 7.29 (EL7).
- Update affected renderer snapshots.