### PR TITLE
Fixes #39536 - preserve RAILS_LOG_TO_STDOUT in foreman-rake

### DIFF
--- a/script/foreman-rake
+++ b/script/foreman-rake
@@ -15,5 +15,6 @@ if [ $# -eq 0 ]; then
 elif [ "$USERNAME" = foreman ]; then
   RUBYOPT=-W0 RAILS_ENV=production $CMD "$@"
 else
-  runuser - foreman -s /bin/bash -c 'RUBYOPT=-W0 RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
+  runuser -w RAILS_LOG_TO_STDOUT \
+    - foreman -s /bin/bash -c 'RUBYOPT=-W0 RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
 fi


### PR DESCRIPTION
## Description

Fixes [#39536](https://projects.theforeman.org/issues/39536).

`foreman-rake` runs Rails via `runuser -`, which starts a login shell and clears most environment variables before switching to the `foreman` user. As a result, `RAILS_LOG_TO_STDOUT` was lost during install-time rake executions, causing Rails to fall back to `production.log` even when stdout logging was intended.

This change preserves `RAILS_LOG_TO_STDOUT` across the `runuser` invocation. Container and RPM installs that set the variable now keep stdout logging throughout install-time rake boots and no longer create `/var/log/foreman/production.log`. Systems that do not set `RAILS_LOG_TO_STDOUT` continue using file logging as before.

#### Related PR: https://github.com/theforeman/foreman-oci-images/pull/66
## Prerequisites for testing

- A system (or container) with the `foreman` user and `runuser` available

## Testing scenarios

### 1. Verify `runuser` preserves the environment

```bash
sudo RAILS_LOG_TO_STDOUT=true runuser - foreman -s /bin/bash -c 'echo "[$RAILS_LOG_TO_STDOUT]"'
# Before fix: []

sudo RAILS_LOG_TO_STDOUT=true runuser -w RAILS_LOG_TO_STDOUT - foreman -s /bin/bash -c 'echo "[$RAILS_LOG_TO_STDOUT]"'
# After fix: [true]
```

### 2. Verify `foreman-rake` logs to stdout

With the patched `/usr/sbin/foreman-rake`:

```bash
rm -f /var/log/foreman/production.log

RAILS_LOG_TO_STDOUT=true foreman-rake db:version

ls /var/log/foreman/production.log
# Expected: No such file or directory
```

Boot messages (for example, `Rails cache backend: File`) should appear on stdout.

### 3. Verify existing behavior is unchanged

Run `foreman-rake` without `RAILS_LOG_TO_STDOUT`:

```bash
unset RAILS_LOG_TO_STDOUT
foreman-rake db:version
```

Rails should continue using `production.log`, matching the existing behavior for traditional installations.
