### PR TITLE
Fixes #39538 - Host actions are disabled after bulk action

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
@@ -31,12 +31,6 @@ import {
   LOCATION_KEY,
   MODAL_TYPES,
 } from './BulkAssignTaxonomyConstants';
-import { foremanUrl } from '../../../../common/helpers';
-import { APIActions } from '../../../../redux/API';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from '../../../../routes/Hosts/constants';
 import TaxonomySelect from './TaxonomySelect';
 import { buildBulkRequestBody } from '../helpers';
 
@@ -56,6 +50,7 @@ const BulkAssignTaxonomyModal = ({
   organizationId,
   locationId,
   modalType,
+  onSuccess: onSuccessCallback,
 }) => {
   const org = modalType === MODAL_TYPES.ORGANIZATION;
   const taxType = org ? 'organization' : 'location';
@@ -129,12 +124,7 @@ const BulkAssignTaxonomyModal = ({
         message: response.data.message,
       })
     );
-    dispatch(
-      APIActions.get({
-        key: API_REQUEST_KEY,
-        url: foremanUrl(HOSTS_API_PATH),
-      })
-    );
+    if (onSuccessCallback) onSuccessCallback();
     handleModalClose();
   };
 
@@ -249,6 +239,7 @@ BulkAssignTaxonomyModal.propTypes = {
   organizationId: PropTypes.number,
   locationId: PropTypes.number,
   modalType: PropTypes.string.isRequired,
+  onSuccess: PropTypes.func,
 };
 
 BulkAssignTaxonomyModal.defaultProps = {
@@ -256,4 +247,5 @@ BulkAssignTaxonomyModal.defaultProps = {
   closeModal: () => {},
   organizationId: undefined,
   locationId: undefined,
+  onSuccess: undefined,
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/index.js
@@ -13,6 +13,7 @@ export const BulkAssignOrganizationModalScene = ({ isOpen, closeModal }) => {
     fetchBulkParams,
     organizationId,
     locationId,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkAssignOrganizationModal
@@ -24,6 +25,7 @@ export const BulkAssignOrganizationModalScene = ({ isOpen, closeModal }) => {
       locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
     />
   );
 };
@@ -35,6 +37,7 @@ export const BulkAssignLocationModalScene = ({ isOpen, closeModal }) => {
     fetchBulkParams,
     organizationId,
     locationId,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkAssignLocationModal
@@ -46,6 +49,7 @@ export const BulkAssignLocationModalScene = ({ isOpen, closeModal }) => {
       locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
     />
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/BulkChangeOwnerModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/BulkChangeOwnerModal.js
@@ -23,17 +23,11 @@ import {
   USER_KEY,
   USERGROUP_KEY,
 } from './actions';
-import { foremanUrl } from '../../../../common/helpers';
-import { APIActions } from '../../../../redux/API';
 import { STATUS } from '../../../../constants';
 import {
   selectAPIStatus,
   selectAPIResponse,
 } from '../../../../redux/API/APISelectors';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from '../../../../routes/Hosts/constants';
 import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 
 const BulkChangeOwnerModal = ({
@@ -44,6 +38,7 @@ const BulkChangeOwnerModal = ({
   fetchBulkParams,
   organizationId,
   locationId,
+  onSuccess: onSuccessCallback,
 }) => {
   const dispatch = useDispatch();
   const [ownerId, setOwnerId] = useState('');
@@ -123,12 +118,7 @@ const BulkChangeOwnerModal = ({
         message: response.data.message,
       })
     );
-    dispatch(
-      APIActions.get({
-        key: API_REQUEST_KEY,
-        url: foremanUrl(HOSTS_API_PATH),
-      })
-    );
+    if (onSuccessCallback) onSuccessCallback();
     handleModalClose();
   };
 
@@ -254,6 +244,7 @@ BulkChangeOwnerModal.propTypes = {
   selectAllHostsMode: PropTypes.bool.isRequired,
   organizationId: PropTypes.number,
   locationId: PropTypes.number,
+  onSuccess: PropTypes.func,
 };
 
 BulkChangeOwnerModal.defaultProps = {
@@ -261,6 +252,7 @@ BulkChangeOwnerModal.defaultProps = {
   closeModal: () => {},
   organizationId: undefined,
   locationId: undefined,
+  onSuccess: undefined,
 };
 
 export default BulkChangeOwnerModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/index.js
@@ -11,6 +11,7 @@ const BulkChangeOwnerModalScene = ({ isOpen, closeModal }) => {
     fetchBulkParams,
     organizationId,
     locationId,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkChangeOwnerModal
@@ -23,6 +24,7 @@ const BulkChangeOwnerModalScene = ({ isOpen, closeModal }) => {
       locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
     />
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/BulkDisassociateModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/BulkDisassociateModal.js
@@ -10,14 +10,8 @@ import {
   TreeView,
 } from '@patternfly/react-core';
 import { addToast } from '../../../ToastsList/slice';
-import { foremanUrl } from '../../../../common/helpers';
 import { translate as __ } from '../../../../common/I18n';
 import { BULK_DISASSOCIATE_KEY, bulkDisassociate } from './actions';
-import { APIActions } from '../../../../redux/API';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from '../../../../routes/Hosts/constants';
 import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 
 const BulkDisassociateModal = ({
@@ -29,6 +23,7 @@ const BulkDisassociateModal = ({
   fetchBulkParams,
   organizationId,
   locationId,
+  onSuccess: onSuccessCallback,
 }) => {
   const dispatch = useDispatch();
   const hostsWithComputeResource = selectedResults?.filter(
@@ -80,12 +75,7 @@ const BulkDisassociateModal = ({
         message: response.data.message,
       })
     );
-    dispatch(
-      APIActions.get({
-        key: API_REQUEST_KEY,
-        url: foremanUrl(HOSTS_API_PATH),
-      })
-    );
+    if (onSuccessCallback) onSuccessCallback();
     closeModal();
   };
 
@@ -193,6 +183,7 @@ BulkDisassociateModal.propTypes = {
   selectAllHostsMode: PropTypes.bool.isRequired,
   organizationId: PropTypes.number,
   locationId: PropTypes.number,
+  onSuccess: PropTypes.func,
 };
 
 BulkDisassociateModal.defaultProps = {
@@ -201,6 +192,7 @@ BulkDisassociateModal.defaultProps = {
   selectedResults: [],
   organizationId: undefined,
   locationId: undefined,
+  onSuccess: undefined,
 };
 
 export default BulkDisassociateModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/index.js
@@ -11,6 +11,7 @@ const BulkDisassociateModalScene = ({ isOpen, closeModal }) => {
     fetchBulkParams,
     organizationId,
     locationId,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkDisassociateModal
@@ -23,6 +24,7 @@ const BulkDisassociateModalScene = ({ isOpen, closeModal }) => {
       locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
     />
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/index.js
@@ -3,12 +3,8 @@ import PropTypes from 'prop-types';
 import { ForemanActionsBarContext } from '../../../../components/HostDetails/ActionsBar';
 import BulkManageNotificationsModal from './BulkManageNotificationsModal';
 
-const BulkManageNotificationsModalScene = ({
-  isOpen,
-  closeModal,
-  onSuccess,
-}) => {
-  const { fetchBulkParams, selectedCount = 0 } = useContext(
+const BulkManageNotificationsModalScene = ({ isOpen, closeModal }) => {
+  const { fetchBulkParams, selectedCount = 0, refreshTableData } = useContext(
     ForemanActionsBarContext
   );
   return (
@@ -17,7 +13,7 @@ const BulkManageNotificationsModalScene = ({
       fetchBulkParams={fetchBulkParams}
       isOpen={isOpen}
       closeModal={closeModal}
-      onSuccess={onSuccess}
+      onSuccess={refreshTableData}
     />
   );
 };
@@ -27,9 +23,4 @@ export default BulkManageNotificationsModalScene;
 BulkManageNotificationsModalScene.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   closeModal: PropTypes.func.isRequired,
-  onSuccess: PropTypes.func,
-};
-
-BulkManageNotificationsModalScene.defaultProps = {
-  onSuccess: undefined,
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/BulkPowerStateModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/BulkPowerStateModal.js
@@ -21,12 +21,6 @@ import { POWER_STATES, BULK_POWER_STATE_KEY } from './constants';
 import { bulkChangePowerState } from './actions';
 import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 import { addToast } from '../../../ToastsList/slice';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from '../../../../routes/Hosts/constants';
-import { foremanUrl } from '../../../../common/helpers';
-import { APIActions } from '../../../../redux/API';
 
 const BulkPowerStateModal = ({
   selectedHostsCount,
@@ -35,6 +29,7 @@ const BulkPowerStateModal = ({
   locationId,
   isOpen,
   closeModal,
+  onSuccess: onSuccessCallback,
 }) => {
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [selectedPowerState, setSelectedPowerState] = useState('');
@@ -60,13 +55,7 @@ const BulkPowerStateModal = ({
         message: response.data.message,
       })
     );
-    dispatch(
-      APIActions.get({
-        key: API_REQUEST_KEY,
-        url: foremanUrl(HOSTS_API_PATH),
-      })
-    );
-
+    if (onSuccessCallback) onSuccessCallback();
     cleanup();
   };
 
@@ -212,6 +201,7 @@ BulkPowerStateModal.propTypes = {
   locationId: PropTypes.number,
   isOpen: PropTypes.bool,
   closeModal: PropTypes.func,
+  onSuccess: PropTypes.func,
 };
 
 BulkPowerStateModal.defaultProps = {
@@ -220,6 +210,7 @@ BulkPowerStateModal.defaultProps = {
   locationId: undefined,
   isOpen: false,
   closeModal: () => {},
+  onSuccess: undefined,
 };
 
 export default BulkPowerStateModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/index.js
@@ -9,6 +9,7 @@ const BulkPowerStateModalScene = ({ isOpen, closeModal }) => {
     selectedCount = 0,
     organizationId,
     locationId,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkPowerStateModal
@@ -18,6 +19,7 @@ const BulkPowerStateModalScene = ({ isOpen, closeModal }) => {
       locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
     />
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
@@ -23,14 +23,8 @@ import {
   fetchHostgroups,
   HOSTGROUP_KEY,
 } from './actions';
-import { foremanUrl } from '../../../../common/helpers';
-import { APIActions } from '../../../../redux/API';
 import HostGroupSelect from './HostGroupSelect';
 import SkeletonLoader from '../../../common/SkeletonLoader';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from '../../../../routes/Hosts/constants';
 import './BulkReassignHostgroupModal.scss';
 
 // Helper function to format hostgroup title for display
@@ -79,6 +73,7 @@ const BulkReassignHostgroupModal = ({
   fetchBulkParams,
   organizationId,
   locationId,
+  onSuccess: onSuccessCallback,
 }) => {
   const dispatch = useDispatch();
   const [hostgroupId, setHostgroupId] = useState('');
@@ -144,12 +139,7 @@ const BulkReassignHostgroupModal = ({
         message: response.data.message,
       })
     );
-    dispatch(
-      APIActions.get({
-        key: API_REQUEST_KEY,
-        url: foremanUrl(HOSTS_API_PATH),
-      })
-    );
+    if (onSuccessCallback) onSuccessCallback();
     handleModalClose();
   };
   const handleSave = () => {
@@ -289,6 +279,7 @@ BulkReassignHostgroupModal.propTypes = {
   fetchBulkParams: PropTypes.func.isRequired,
   organizationId: PropTypes.number,
   locationId: PropTypes.number,
+  onSuccess: PropTypes.func,
 };
 
 BulkReassignHostgroupModal.defaultProps = {
@@ -296,6 +287,7 @@ BulkReassignHostgroupModal.defaultProps = {
   closeModal: () => {},
   organizationId: undefined,
   locationId: undefined,
+  onSuccess: undefined,
 };
 
 export default BulkReassignHostgroupModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/index.js
@@ -9,6 +9,7 @@ const BulkReassignHostgroupModalScene = ({ isOpen, closeModal }) => {
     fetchBulkParams,
     organizationId,
     locationId,
+    refreshTableData,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkReassignHostgroupModal
@@ -19,6 +20,7 @@ const BulkReassignHostgroupModalScene = ({ isOpen, closeModal }) => {
       locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
+      onSuccess={refreshTableData}
     />
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -231,7 +231,7 @@ const HostsIndex = () => {
   const refreshTableData = () =>
     setAPIOptions({
       ...apiOptions,
-      params: { search: urlSearchQuery },
+      params: { ...params, search: urlSearchQuery, page: 1 },
     });
   const deleteHostHandler = ({ hostName, computeId }) =>
     dispatch(
@@ -597,6 +597,7 @@ const HostsIndex = () => {
             fetchBulkParams,
             organizationId: currentOrganization?.id,
             locationId: currentLocation?.id,
+            refreshTableData,
           }}
         >
           <BulkAssignOrganizationModal
@@ -638,13 +639,6 @@ const HostsIndex = () => {
             key="bulk-manage-notifications-modal"
             isOpen={notificationsModalOpen}
             closeModal={() => setNotificationsModalOpen(false)}
-            // Re-fetch hosts with the current search so the table stays in sync
-            onSuccess={() =>
-              setAPIOptions({
-                ...apiOptions,
-                params: { search: urlSearchQuery },
-              })
-            }
           />
           <Slot id="_all-hosts-modals" multi />
         </ForemanActionsBarContext.Provider>


### PR DESCRIPTION
new host page - to reproduce run one of the bulk actions - for example: change location, after the data refresh, the permissions dont get loaded, so the host kebab (edit,clone, clone) are disabled.
Updated all bulk actions to use the same refresh data function, that includes permissions.