### PR TITLE
Drop pkg:deb rake task

### DIFF
--- a/lib/tasks/pkg.rake
+++ b/lib/tasks/pkg.rake
@@ -2,22 +2,6 @@ require 'English'
 require 'fileutils'
 
 namespace :pkg do
-  desc 'Create DEB package with `debuild`.'
-  task :deb do
-    # copy 'debian' directory from 'extras' into main directory
-    FileUtils.cp_r 'extras/debian/', Rake.application.original_dir + '/debian'
-
-    # run 'debuild'
-    system 'debuild'
-
-    if $CHILD_STATUS == 0
-      # remove 'debian' directory
-      FileUtils.rm_r Rake.application.original_dir + '/debian', :force => true
-    else
-      abort 'Error while building the DEB package with `debuild`. Please check the output.'
-    end
-  end
-
   desc 'Generate package source tar.bz2, supply ref=<tag> for tags'
   task :generate_source do
     File.exist?('pkg') || FileUtils.mkdir('pkg')


### PR DESCRIPTION
This now all lives in foreman-packaging

Fixes: d2b7a8a2ec9e3f00795a10aa32661ea9828f3f71


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
