### PR TITLE
Fixes #39547 - Automatically change title to text in APIActions

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ToastsList/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/helpers.js
@@ -20,7 +20,7 @@ export const toastType = type => {
   return fallbackTypes[type] || AlertVariant.custom;
 };
 
-const MAX_TOAST_TITLE_LENGTH = 60;
+export const MAX_TOAST_TITLE_LENGTH = 60;
 
 export const toastTitle = (message, type) => {
   if (message.length <= MAX_TOAST_TITLE_LENGTH) return message;

--- a/webpack/assets/javascripts/react_app/components/ToastsList/index.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/index.js
@@ -15,6 +15,13 @@ import './style.scss';
 
 const TOAST_TIMEOUT_MS = 8000;
 
+const wrapToastMessage = message =>
+  typeof message === 'string' && message.length > MAX_TOAST_TITLE_LENGTH ? (
+    <div>{message}</div>
+  ) : (
+    message
+  );
+
 const ToastsList = ({ railsMessages }) => {
   const dispatch = useDispatch();
   const messages = useSelector(selectToastsList);
@@ -26,32 +33,36 @@ const ToastsList = ({ railsMessages }) => {
   }, [dispatch, railsMessages]);
 
   const toastsList = Object.entries(messages).map(
-    ([key, { type, message, link, sticky, ...toastProps }]) => (
-      <Alert
-        ouiaId={`toast-item-${key}`}
-        key={key}
-        title={toastTitle(message, toastType(type))}
-        variant={toastType(type)}
-        timeout={sticky ? false : TOAST_TIMEOUT_MS}
-        onTimeout={() => dispatch(deleteToast(key))}
-        className="foreman-toast"
-        actionClose={
-          <AlertActionCloseButton onClose={() => dispatch(deleteToast(key))} />
-        }
-        actionLinks={
-          link && (
-            <AlertActionLink>
-              <a href={link.href}>{link.children}</a>
-            </AlertActionLink>
-          )
-        }
-        {...toastProps}
-      >
-        {(message.length > MAX_TOAST_TITLE_LENGTH ||
-          React.isValidElement(message)) &&
-          message}
-      </Alert>
-    )
+    ([key, { type, message, link, sticky, ...toastProps }]) => {
+      const displayMessage = wrapToastMessage(message);
+
+      return (
+        <Alert
+          ouiaId={`toast-item-${key}`}
+          key={key}
+          title={toastTitle(message, toastType(type))}
+          variant={toastType(type)}
+          timeout={sticky ? false : TOAST_TIMEOUT_MS}
+          onTimeout={() => dispatch(deleteToast(key))}
+          className="foreman-toast"
+          actionClose={
+            <AlertActionCloseButton
+              onClose={() => dispatch(deleteToast(key))}
+            />
+          }
+          actionLinks={
+            link && (
+              <AlertActionLink>
+                <a href={link.href}>{link.children}</a>
+              </AlertActionLink>
+            )
+          }
+          {...toastProps}
+        >
+          {React.isValidElement(displayMessage) && displayMessage}
+        </Alert>
+      );
+    }
   );
 
   return toastsList.length > 0 && <AlertGroup isToast>{toastsList}</AlertGroup>;


### PR DESCRIPTION
Using successToast or errorToast with response message can exceeds maximum size of the title (60 chars), this wrap the string in `<div>` if it's longer then the limit.