### PR TITLE
Fixes #39562 - Update eslint-plugin-rules require-ouiaid with PF5 components

### DIFF
--- a/script/lint/@theforeman/eslint-plugin-rules/require-ouiaid.js
+++ b/script/lint/@theforeman/eslint-plugin-rules/require-ouiaid.js
@@ -3,48 +3,59 @@ const getProp = require('jsx-ast-utils/getProp');
 module.exports = {
   create(context) {
     const patternflyImports = new Set();
-    const options = context.options.length
-      ? context.options
-      : [
-          'Alert',
-          'Breadcrumb',
-          'Button',
-          'Card',
-          'Checkbox',
-          'Chip',
-          'ChipGroup',
-          'ContextSelector',
-          'Dropdown',
-          'DropdownItem',
-          'DropdownSeparator',
-          'DropdownToggle',
-          'DropdownToggleCheckbox',
-          'FormSelect',
-          'Menu',
-          'Modal',
-          'ModalBoxCloseButton',
-          'ModalContent',
-          'Nav',
-          'NavExpandable',
-          'NavItem',
-          'OptionsMenu',
-          'Pagination',
-          'Radio',
-          'RowWrapper',
-          'Select',
-          'Switch',
-          'TabButton',
-          'TabContent',
-          'Tab',
-          'Tabs',
-          'Text',
-          'TextInput',
-          'Title',
-          'Toolbar',
-          'Table',
-          'TableComposable',
-          'Tr',
-        ];
+    const defaults = [
+      'Alert',
+      'Breadcrumb',
+      'Button',
+      'Card',
+      'Checkbox',
+      'Chip',
+      'ChipGroup',
+      'ClipboardCopy',
+      'ContextSelector',
+      'Dropdown',
+      'DropdownItem',
+      'DropdownSeparator',
+      'DropdownToggle',
+      'DropdownToggleCheckbox',
+      'FormSelect',
+      'Menu',
+      'MenuToggle',
+      'Modal',
+      'ModalBoxCloseButton',
+      'ModalContent',
+      'Nav',
+      'NavExpandable',
+      'NavItem',
+      'OptionsMenu',
+      'Pagination',
+      'Radio',
+      'RowWrapper',
+      'Select',
+      'Switch',
+      'Tab',
+      'TabButton',
+      'TabContent',
+      'Table',
+      'TableComposable',
+      'Tabs',
+      'Text',
+      'TextInput',
+      'Title',
+      'Toolbar',
+      'Tr',
+    ];
+
+    const { additional } =
+      (context.options.length === 1 && context.options[0]) || {};
+    const { options: contextOptions } = context;
+
+    let options = defaults;
+    if (additional) {
+      options = [...defaults, ...additional];
+    } else if (contextOptions.length) {
+      options = contextOptions;
+    }
 
     function addPatternflyImport(node) {
       if (

--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorSettings.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorSettings.js
@@ -42,6 +42,7 @@ const SettingsSelect = ({
         toggle={toggleRef => (
           <MenuToggle
             ref={toggleRef}
+            ouiaId="editor-settings-toggle"
             onClick={() => {
               if (!disabled) {
                 setIsOpen(!isOpen);

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/ErrorsTree/components/ErrorPresenter.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/ErrorsTree/components/ErrorPresenter.js
@@ -7,6 +7,7 @@ export const ErrorPresenter = props => (
   <ClipboardCopy
     isReadOnly
     isBlock
+    ouiaId="clipboard-copy-error"
     hoverTip={__('Copy')}
     clickTip={__('Copied!')}
     variant="inline-compact"

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -220,6 +220,7 @@ const ActionsBar = ({
                 <MenuToggle
                   ref={toggleRef}
                   id="hostdetails-kebab"
+                  ouiaId="host-details-kebab-toggle"
                   variant="plain"
                   isExpanded={kebabIsOpen}
                   onClick={() => onKebabToggle(!kebabIsOpen)}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/index.js
@@ -73,7 +73,11 @@ const DetailsCard = ({
                 status={status}
               >
                 {ip6 && (
-                  <ClipboardCopy isBlock variant="inline-compact">
+                  <ClipboardCopy
+                    isBlock
+                    variant="inline-compact"
+                    ouiaId="clipboard-copy-ipv6"
+                  >
                     {ip6}
                   </ClipboardCopy>
                 )}
@@ -88,7 +92,11 @@ const DetailsCard = ({
                 status={status}
               >
                 {ip && (
-                  <ClipboardCopy isBlock variant="inline-compact">
+                  <ClipboardCopy
+                    isBlock
+                    variant="inline-compact"
+                    ouiaId="clipboard-copy-ipv4"
+                  >
                     {ip}
                   </ClipboardCopy>
                 )}
@@ -103,7 +111,11 @@ const DetailsCard = ({
                 status={status}
               >
                 {mac && (
-                  <ClipboardCopy isBlock variant="inline-compact">
+                  <ClipboardCopy
+                    isBlock
+                    variant="inline-compact"
+                    ouiaId="clipboard-copy-mac"
+                  >
                     {mac}
                   </ClipboardCopy>
                 )}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
@@ -47,6 +47,7 @@ const SystemPropertiesCard = ({ status, hostDetails }) => {
                 <ClipboardCopy
                   isBlock
                   variant="inline-compact"
+                  ouiaId="clipboard-copy-name"
                   hoverTip={__('Copy to clipboard')}
                   clickTip={__('Copied to clipboard')}
                 >
@@ -72,7 +73,11 @@ const SystemPropertiesCard = ({ status, hostDetails }) => {
               emptyState={<DefaultLoaderEmptyState />}
             >
               {domain && (
-                <ClipboardCopy isBlock variant="inline-compact">
+                <ClipboardCopy
+                  isBlock
+                  variant="inline-compact"
+                  ouiaId="clipboard-copy-domain"
+                >
                   {domain}
                 </ClipboardCopy>
               )}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/TemplatesCard/ReviewModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/TemplatesCard/ReviewModal.js
@@ -105,6 +105,7 @@ export const ReviewModal = ({
             isExpanded
             isReadOnly
             isCode
+            ouiaId="clipboard-copy-template-review"
             variant={ClipboardCopyVariant.expansion}
           >
             {response}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -81,6 +81,7 @@ const CardTemplate = ({
                     toggle={toggleRef => (
                       <MenuToggle
                         ref={toggleRef}
+                        ouiaId="template-card-dropdown-toggle"
                         variant="plain"
                         isExpanded={dropdownVisibility}
                         onClick={() => onDropdownToggle(!dropdownVisibility)}

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/ActionKebab.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/ActionKebab.js
@@ -51,6 +51,7 @@ export const ActionKebab = ({ items, menuOpen, setMenuOpen }) => {
   const menuToggle = (
     <MenuToggle
       variant="plain"
+      ouiaId="hosts-index-kebab-toggle"
       aria-label="plain kebab"
       onClick={() => setMenuOpen(prev => !prev)}
       isExpanded={menuOpen}

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
@@ -90,6 +90,7 @@ const BulkAssignTaxonomyModal = ({
   const toggle = toggleRef => (
     <MenuToggle
       ref={toggleRef}
+      ouiaId="bulk-assign-taxonomy-toggle"
       onClick={onToggleClick}
       isExpanded={selectOpen}
       style={{ width: '95%' }}

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/BulkChangeOwnerModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/BulkChangeOwnerModal.js
@@ -86,6 +86,7 @@ const BulkChangeOwnerModal = ({
   const toggle = toggleRef => (
     <MenuToggle
       ref={toggleRef}
+      ouiaId="bulk-change-owner-toggle"
       onClick={onToggleClick}
       isExpanded={ownerSelectOpen}
       style={{ width: '500px' }}

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/BulkPowerStateModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/BulkPowerStateModal.js
@@ -172,6 +172,7 @@ const BulkPowerStateModal = ({
           toggle={toggleRef => (
             <MenuToggle
               ref={toggleRef}
+              ouiaId="power-state-toggle"
               onClick={() => setIsSelectOpen(!isSelectOpen)}
               isExpanded={isSelectOpen}
               style={{ width: '100%' }}

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/HostGroupSelect.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/HostGroupSelect.js
@@ -43,6 +43,7 @@ const HostGroupSelect = ({
   const toggle = toggleRef => (
     <MenuToggle
       ref={toggleRef}
+      ouiaId="host-group-select-toggle"
       variant="typeahead"
       aria-label="Typeahead menu toggle"
       onClick={onToggleClick}

--- a/webpack/assets/javascripts/react_app/components/SearchBar/AutoCompleteMenu.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/AutoCompleteMenu.js
@@ -19,6 +19,7 @@ export const AutoCompleteMenu = ({ results, error }) => {
             isBlock
             isReadOnly
             variant="inline-compact"
+            ouiaId="clipboard-copy-search-error"
             hoverTip={__('Copy to clipboard')}
             clickTip={__('Copied to clipboard')}
           >

--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.js
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.js
@@ -43,6 +43,7 @@ export const ActionButtons = ({ buttons }) => {
       toggle={toggleRef => (
         <MenuToggle
           ref={toggleRef}
+          ouiaId="action-buttons-toggle"
           variant="secondary"
           aria-label="Menu toggle with action split button"
           isExpanded={isOpen}

--- a/webpack/assets/javascripts/react_app/components/common/AutocompleteInput/AutocompleteInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/AutocompleteInput/AutocompleteInput.js
@@ -147,6 +147,7 @@ export const AutocompleteInputComponent = ({
   const toggle = toggleRef => (
     <MenuToggle
       ref={toggleRef}
+      ouiaId="autocomplete-input-toggle"
       variant="typeahead"
       aria-label="Typeahead menu toggle"
       onClick={onToggleClick}

--- a/webpack/assets/javascripts/react_app/components/common/ClipboardCopy/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/ClipboardCopy/index.js
@@ -15,6 +15,7 @@ const ClipboardCopy = ({ text: defaultText, textareaProps }) => (
     isExpanded
     isReadOnly={textareaProps.readOnly ?? false}
     className={textareaProps.className ?? null}
+    ouiaId="clipboard-copy-init-config"
   >
     {defaultText}
   </PFClipboardCopy>

--- a/webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.js
@@ -80,7 +80,11 @@ class ErrorBoundary extends React.Component {
           />
         </GridItem>
         <GridItem sm={8} smOffset={2}>
-          <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
+          <ClipboardCopy
+            isReadOnly
+            ouiaId="clipboard-copy-error-boundary"
+            variant={ClipboardCopyVariant.expansion}
+          >
             {error.toString()}
             {info.componentStack}
           </ClipboardCopy>

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/NewPersonalAccessToken.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/NewPersonalAccessToken.js
@@ -21,6 +21,7 @@ const NewTokenInfo = ({ newPersonalAccessToken, onDismiss }) => (
         >
           <ClipboardCopy
             isReadOnly
+            ouiaId="clipboard-copy-personal-access-token"
             hoverTip={__('Copy to clipboard')}
             clickTip={__('Copied to clipboard')}
             variant="inline-compact"

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Command.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Command.js
@@ -30,6 +30,7 @@ const Command = ({ apiStatus, command }) => {
             isReadOnly
             isCode
             isExpanded
+            ouiaId="clipboard-copy-registration-command"
           >
             {command}
           </ClipboardCopy>


### PR DESCRIPTION
- Update `require-ouiaid` eslint rule for PatternFly 5 compatibility
- **Added**: `MenuToggle` (PF5 replacement for `DropdownToggle`) and `ClipboardCopy` (existing PF component, previously missing from the list)
- Add `additional` option parameter to extend the defaults list without overriding them
- Sort component list alphabetically

**Test plan**
 - Verify the rule catches missing `ouiaId` on newly added components (e.g. `MenuToggle`):
```
cp /home/vagrant/foreman/script/lint/@theforeman/eslint-plugin-rules/require-ouiaid.js \
   /home/vagrant/foreman/node_modules/@theforeman/eslint-plugin-rules/lib/require-ouiaid.js
```
```
cd /home/vagrant/foreman
npx eslint \
  --plugin @theforeman/rules \
  --rule '@theforeman/rules/require-ouiaid: error' \
  ../foreman_rh_cloud/webpack/
```

 - Verify the additional option works to extend defaults:
```
cat > /home/vagrant/foreman/ouiaid-test.json << 'EOF'
{
  "parser": "babel-eslint",
  "plugins": ["@theforeman/rules"],
  "rules": {
    "@theforeman/rules/require-ouiaid": ["error", { "additional": ["MyExtraComponent"] }]
  }
}
EOF
```
```
cd /home/vagrant/foreman
npx -c ouiaid-test.json ../foreman_rh_cloud/webpack/
```

List of OUIA-compliant PatternFly components:
- [PatternFly 5](https://v5-archive.patternfly.org/developer-resources/open-ui-automation/)
- [PatternFly 4](https://v4-archive.patternfly.org/v4/developer-resources/open-ui-automation)