### PR TITLE
Fixes #39564 - prevent double JSON serialization of parameter values on hostgroup parent change

### DIFF
--- a/app/models/concerns/key_type.rb
+++ b/app/models/concerns/key_type.rb
@@ -14,9 +14,9 @@ module KeyType
       if key_type.present?
         case key_type.to_sym
           when :json, :array
-            val = JSON.dump(val)
+            val = JSON.dump(val) unless val.is_a?(String)
           when :yaml, :hash
-            val = YAML.dump val
+            val = YAML.dump val unless val.is_a?(String)
             val.sub!(/\A---\s*$\n/, '')
         end
       end

--- a/test/unit/concerns/key_type_test.rb
+++ b/test/unit/concerns/key_type_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class KeyTypeTest < ActiveSupport::TestCase
+  test "format_value_before_type_cast does not double encode json string" do
+    val = '["server","admin-access"]'
+    result = Parameter.format_value_before_type_cast(val, "json")
+    assert_equal val, result
+  end
+
+  test "format_value_before_type_cast correctly serializes ruby array to json" do
+    val = ["server", "admin-access"]
+    result = Parameter.format_value_before_type_cast(val, "json")
+    assert_equal JSON.dump(val), result
+  end
+
+  test "format_value_before_type_cast does not double encode yaml string" do
+    val = "key: value"
+    result = Parameter.format_value_before_type_cast(val, "yaml")
+    assert_equal val, result
+  end
+end


### PR DESCRIPTION
## Problem

When changing the parent hostgroup of a hostgroup that has a json or
array type parameter, the parameter value gets corrupted with escaped
quotes on every save.

Before parent change: ["server","admin-access"]
After parent change:  [\"server\",\"admin-access\"]

## Root Cause

`format_value_before_type_cast` in `key_type.rb` unconditionally calls
`JSON.dump(val)` even when `val` is already a String.

During the `process_hostgroup` AJAX re-render triggered by a parent
change, the Ruby Array gets serialized to a JSON String for the form
field. When the form is submitted, that String goes through `JSON.dump`
a second time, double-encoding it and corrupting the value permanently.

## Fix

Added `unless val.is_a?(String)` guard to `JSON.dump` and `YAML.dump`
calls in `format_value_before_type_cast`.

- If value is already a String → skip serialization → no corruption
- If value is a Ruby Array or Hash → serialize normally → unchanged behavior

## Testing

- Existing tests: 7 tests, 0 failures
- New tests added in `test/unit/concerns/key_type_test.rb`:
  - Proves bug is fixed: already-String value is not double encoded
  - Proves normal behavior: Ruby Array is correctly serialized to JSON
  - Proves yaml fix: already-String yaml value is not double encoded

Fixes #39564