### PR TITLE
Fixes #39568 - Share time unit JS consts for plugins

### DIFF
--- a/webpack/assets/javascripts/react_app/constants.js
+++ b/webpack/assets/javascripts/react_app/constants.js
@@ -3,6 +3,12 @@ import { getManualURL } from './common/helpers';
 export const MS_PER_SECOND = 1000;
 export const PERCENT_MULTIPLIER = 100;
 export const BYTES_PER_KB = 1024;
+export const SECONDS_PER_MINUTE = 60;
+export const MINUTES_PER_HOUR = 60;
+export const HOURS_PER_HALF_DAY = 12;
+export const HOURS_PER_DAY = 24;
+export const DAYS_PER_WEEK = 7;
+export const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE;
 
 export const HTTP_STATUS_CODES = {
   OK: 200,


### PR DESCRIPTION

Add shared time-unit constants to foremanReact/constants so plugins can import them instead of redeclaring the same values.