### PR TITLE
Fixes #39570 - fix auth_smart_proxy hostname collision with multiple proxies

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -79,7 +79,7 @@ module Foreman::Controller::SmartProxyAuth
     return false unless request_hosts
     Rails.logger.info request_hosts
 
-    hosts = Hash[proxies.map { |p| [URI.parse(p.url).host, p] }]
+    hosts = proxies.group_by { |p| URI.parse(p.url).host }
 
     # For loopback addresses in non-SSL mode, only match against trusted_hosts,
     # not registered smart proxy URLs. This prevents local processes from
@@ -94,7 +94,7 @@ module Foreman::Controller::SmartProxyAuth
     end
 
     if (host = detect_matching_host(allowed_hosts, request_hosts))
-      @detected_proxy = hosts[host] if host
+      @detected_proxy = hosts[host]&.first
       true
     else
       logger.warn "No smart proxy server found on #{request_hosts.inspect} and is not in trusted_hosts"

--- a/test/controllers/smart_proxy_auth_test.rb
+++ b/test/controllers/smart_proxy_auth_test.rb
@@ -108,6 +108,19 @@ class SmartProxyAuthApiTest < ActionController::TestCase
     assert_equal proxy, @controller.detected_proxy
   end
 
+  def test_multiple_proxies_with_same_hostname
+    Setting[:ssl_client_dn_env] = 'SSL_CLIENT_S_DN'
+    Setting[:ssl_client_verify_env] = 'SSL_CLIENT_VERIFY'
+    @request.env['HTTPS'] = 'on'
+    @request.env['SSL_CLIENT_S_DN'] = 'CN=proxy.example.com'
+    @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
+
+    proxy1 = FactoryBot.create(:smart_proxy, :url => 'https://proxy.example.com:8443')
+    proxy2 = FactoryBot.create(:smart_proxy, :url => 'https://proxy.example.com/pulp/api/v3/smart_proxy')
+    assert @controller.send(:auth_smart_proxy)
+    assert_includes [proxy1, proxy2], @controller.detected_proxy
+  end
+
   def test_wild_card_certificates_are_supported
     Setting[:ssl_client_dn_env] = 'SSL_CLIENT_S_DN'
     Setting[:ssl_client_verify_env] = 'SSL_CLIENT_VERIFY'


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `auth_smart_proxy` where multiple Smart Proxies with the same hostname would be silently dropped due to using `Hash[]` for grouping.

## Related PR

This PR is related to https://github.com/Katello/katello/pull/11807

## Details

The `auth_smart_proxy` method uses `Hash[proxies.map { |p| [p.hostname, p] }]` to group proxies by hostname. When multiple proxies share the same hostname (e.g., a Registration proxy and a Pulpcore proxy on the same server), the Hash constructor silently drops all but one proxy, causing authentication to fail for requests from the dropped proxies.

This fix replaces `Hash[]` with `group_by` to properly handle multiple proxies with the same hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)