### PR TITLE
Fixes #39572 - Reject network address that contains a CIDR suffix

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -107,6 +107,7 @@ class Subnet < ApplicationRecord
 
   validate :validate_ranges
   validate :check_if_type_changed, :on => :update
+  validate :network_must_not_contain_prefix
 
   default_scope lambda {
     with_taxonomy_scope do
@@ -385,20 +386,21 @@ class Subnet < ApplicationRecord
     end
   end
 
+  def network_must_not_contain_prefix
+    return unless network.present? && network.to_s.include?('/')
+
+    errors.add(:network, _("must not include a CIDR prefix"))
+  end
+
   def normalize_addresses
     IP_FIELDS.each do |f|
       val = send(f)
+      # Skip normalization for a network that still carries a CIDR suffix;
+      # it will be rejected by network_must_not_contain_prefix.
+      next if f == :network && val.to_s.include?('/')
       send("#{f}=", normalize_ip(val)) if val.present?
     end
-    strip_network_cidr
     self
-  end
-
-  def strip_network_cidr
-    return unless network.present? && network.include?('/')
-    parts = network.split('/')
-    self.network = parts[0]
-    self.cidr = parts[1].to_i if mask.blank? || cidr.nil?
   end
 
   def ensure_ip_addrs_valid

--- a/test/models/subnet/ipv6_test.rb
+++ b/test/models/subnet/ipv6_test.rb
@@ -64,16 +64,16 @@ class Subnet::Ipv6Test < ActiveSupport::TestCase
   end
 
   test "should find the subnet with highest CIDR prefix by IP order A" do
-    Subnet::Ipv6.create!(:network => "2001:db8::/32", :mask => "ffff:ffff::", :name => "net_32")
-    to_find = Subnet::Ipv6.create!(:network => "2001:db8::/33", :mask => "  ffff:ffff:8000::", :name => "net_33")
+    Subnet::Ipv6.create!(:network => "2001:db8::", :mask => "ffff:ffff::", :name => "net_32")
+    to_find = Subnet::Ipv6.create!(:network => "2001:db8::", :mask => "  ffff:ffff:8000::", :name => "net_33")
     assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::1")
     assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::13")
     assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::cafe")
   end
 
   test "should find the subnet with highest CIDR prefix by IP order B" do
-    to_find = Subnet::Ipv6.create!(:network => "2001:db8::/33", :mask => "  ffff:ffff:8000::", :name => "net_33")
-    Subnet::Ipv6.create!(:network => "2001:db8::/32", :mask => "ffff:ffff::", :name => "net_32")
+    to_find = Subnet::Ipv6.create!(:network => "2001:db8::", :mask => "  ffff:ffff:8000::", :name => "net_33")
+    Subnet::Ipv6.create!(:network => "2001:db8::", :mask => "ffff:ffff::", :name => "net_32")
     assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::1")
     assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::13")
     assert_equal to_find, Subnet::Ipv6.subnet_for("2001:db8::cafe")

--- a/test/models/subnet_test.rb
+++ b/test/models/subnet_test.rb
@@ -163,31 +163,56 @@ class SubnetTest < ActiveSupport::TestCase
     results = Subnet.search_for(%{params.#{parameter.name} ~ "192"})
     assert results.include?(subnet)
   end
-  describe '#strip_network_cidr' do
-    test 'should strip CIDR prefix from network address' do
-      subnet = FactoryBot.build(:subnet_ipv4, :network => '192.168.1.0/24', :mask => '255.255.255.0')
-      subnet.valid?
-      assert_equal '192.168.1.0', subnet.network
-    end
 
-    test 'should not modify network address without CIDR' do
-      subnet = FactoryBot.build(:subnet_ipv4, :network => '192.168.1.0', :mask => '255.255.255.0')
-      subnet.valid?
-      assert_equal '192.168.1.0', subnet.network
-    end
+  test 'should reject network address that contains cidr suffix' do
+    subnet = FactoryBot.build(:subnet_ipv4,
+      :network => '192.168.24.0/24',
+      :mask => '255.255.255.0'
+    )
+    refute subnet.valid?
+    assert_includes subnet.errors[:network], 'must not include a CIDR prefix'
+  end
 
-    test 'should set cidr from network CIDR when mask is blank' do
-      subnet = Subnet::Ipv4.new(:name => 'test', :network => '10.0.0.0/8')
-      subnet.valid?
-      assert_equal '10.0.0.0', subnet.network
-      assert_equal 8, subnet.cidr
-    end
+  test 'should reject network address with cidr suffix even when mask is invalid' do
+    subnet = FactoryBot.build(:subnet_ipv4,
+      :network => '192.168.24.0/24',
+      :mask => 'not-a-mask'
+    )
+    refute subnet.valid?
+    assert_includes subnet.errors[:network], 'must not include a CIDR prefix'
+  end
 
-    test 'should not produce duplicated prefix after save' do
-      subnet = FactoryBot.build(:subnet_ipv4, :network => '192.168.1.0/24', :mask => '255.255.255.0')
-      subnet.valid?
-      assert_equal '192.168.1.0/24', subnet.network_address
-      refute_match %r{/24/24}, subnet.network_address
-    end
+  test 'should accept network address without cidr suffix' do
+    subnet = FactoryBot.build(:subnet_ipv4,
+      :network => '192.168.24.0',
+      :mask => '255.255.255.0'
+    )
+    assert subnet.valid?
+  end
+
+  test 'should reject ipv6 network address that contains cidr suffix' do
+    subnet = FactoryBot.build(:subnet_ipv6,
+      :network => '2001:db8::/64',
+      :mask => 'ffff:ffff:ffff:ffff::'
+    )
+    refute subnet.valid?
+    assert_includes subnet.errors[:network], 'must not include a CIDR prefix'
+  end
+
+  test 'should reject ipv6 network address with cidr suffix even when mask is invalid' do
+    subnet = FactoryBot.build(:subnet_ipv6,
+      :network => '2001:db8::/64',
+      :mask => 'not-a-mask'
+    )
+    refute subnet.valid?
+    assert_includes subnet.errors[:network], 'must not include a CIDR prefix'
+  end
+
+  test 'should accept ipv6 network address without cidr suffix' do
+    subnet = FactoryBot.build(:subnet_ipv6,
+      :network => '2001:db8::',
+      :mask => 'ffff:ffff:ffff:ffff::'
+    )
+    assert subnet.valid?
   end
 end


### PR DESCRIPTION
## Summary

After #10926 (the fix for #39159) was merged into develop, input validation became inconsistent when the Network Address field contains a CIDR suffix (e.g. the `/24` in `192.168.1.0/24`). In particular, an invalid mask bypasses validation and gets saved, but only when a suffix is present.

#10926 resolved the duplicated-prefix issue (`/24/24`) by stripping the suffix in a `before_validation` hook. However, with that strip approach, whether the suffix is adopted depends on the state of the mask, and an invalid mask can be silently swallowed via the suffix.

This PR changes the direction: instead of stripping the suffix, it rejects a network address that contains a suffix as invalid input. The prefix length continues to be specified via the Network Prefix field.

The direction was discussed on the forum, and there were no objections to the reject approach.
https://community.theforeman.org/t/subnet-network-address-cidr-suffix-validation-direction-after-10926/47109

## Changes

- Remove `strip_network_cidr` and its call from `normalize_addresses`.
- Add a `network_must_not_contain_prefix` validation that adds an `is invalid` error to `network` when it contains a `/`.
- Update tests: remove the existing tests that covered the strip behavior, and add tests confirming that a network address containing a suffix is rejected.

## Related

- Original bug: [#39159](https://projects.theforeman.org/issues/39159)
- PR that introduced the strip behavior: #10926
- Forum discussion: https://community.theforeman.org/t/subnet-network-address-cidr-suffix-validation-direction-after-10926/47109