### PR TITLE
Fixes #39574 - Add self_or_colocated_with_feature method to SmartProxy

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -49,6 +49,12 @@ class SmartProxy < ApplicationRecord
     URI(url).host
   end
 
+  def self_or_colocated_with_feature(feature_name)
+    SmartProxy.unscoped.with_features(feature_name).find do |sp|
+      sp.hostname == hostname
+    end
+  end
+
   def to_s
     hostname
   end

--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -269,4 +269,34 @@ class SmartProxyTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe '#self_or_colocated_with_feature' do
+    test 'returns a proxy on the same host with the requested feature' do
+      proxy_a = FactoryBot.create(:template_smart_proxy, :url => 'https://colocated.example.com:8443')
+      proxy_b = FactoryBot.create(:smart_proxy, :url => 'https://colocated.example.com:9090')
+      proxy_b.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :tftp, :smart_proxy => proxy_b)
+
+      assert_equal proxy_a, proxy_b.self_or_colocated_with_feature('Templates')
+    end
+
+    test 'returns nil when no co-located proxy has the feature' do
+      proxy = FactoryBot.create(:smart_proxy, :url => 'https://lonely.example.com:8443')
+
+      assert_nil proxy.self_or_colocated_with_feature('Templates')
+    end
+
+    test 'returns self when self has the requested feature' do
+      proxy = FactoryBot.create(:template_smart_proxy, :url => 'https://selfmatch.example.com:8443')
+
+      assert_equal proxy, proxy.self_or_colocated_with_feature('Templates')
+    end
+
+    test 'does not match proxies on different hosts' do
+      FactoryBot.create(:template_smart_proxy, :url => 'https://other.example.com:8443')
+      proxy = FactoryBot.create(:smart_proxy, :url => 'https://different.example.com:8443')
+      proxy.smart_proxy_features.destroy_all
+
+      assert_nil proxy.self_or_colocated_with_feature('Templates')
+    end
+  end
 end


### PR DESCRIPTION
### Purpose

This PR adds a reusable `self_or_colocated_with_feature` instance method to `SmartProxy` that finds a proxy on the same hostname with a specific feature — returning self if it already has the feature, or a co-located proxy if not.

### Changes

- Added `self_or_colocated_with_feature(feature_name)` method to `SmartProxy` model
- Added comprehensive test coverage with 4 test cases

### Background

This generalizes a pattern from [Katello PR #11807](https://github.com/Katello/katello/pull/11807) where a `find_pulpcore_proxy` method was needed to find a Pulpcore-enabled proxy on the same host as a Registration proxy. Now any plugin can use `proxy.self_or_colocated_with_feature('SomeFeature')` instead of reimplementing hostname-matching logic.

### Testing

The tests cover:
1. Finding a co-located proxy with the requested feature
2. Returning nil when no co-located proxy has the feature
3. Returning self when the proxy itself has the requested feature
4. Not matching proxies on different hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)