### PR TITLE
Fixes #38275 - Fix N+1s on smart proxies index

### DIFF
--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -6,7 +6,7 @@ class SmartProxiesController < ApplicationController
   before_action :find_status, :only => [:ping, :tftp_server]
 
   def index
-    @smart_proxies = resource_base_search_and_page.includes(:features)
+    @smart_proxies = resource_base_search_and_page.includes(:features, :smart_proxy_features)
   end
 
   def show
@@ -144,7 +144,7 @@ class SmartProxiesController < ApplicationController
   end
 
   def resource_base
-    super.eager_load(:locations, :organizations)
+    super.includes(:locations, :organizations)
   end
 
   def versions_mismatched?(proxy_versions_hash)

--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -23,11 +23,12 @@ module SmartProxiesHelper
 
   def feature_actions(proxy, authorizer)
     actions = []
+    feature_names = proxy.features.map(&:name)
 
     actions << display_link_if_authorized(_("Refresh"), hash_for_refresh_smart_proxy_path(:id => proxy).
                                                                  merge(:auth_object => proxy, :permission => 'edit_smart_proxies', :authorizer => authorizer), :method => :put)
 
-    if proxy.has_feature?('Puppet CA')
+    if feature_names.include?('Puppet CA')
       actions << display_link_if_authorized(_("Certificates"), hash_for_smart_proxy_path(:id => proxy).
                                                                merge(:auth_object => proxy, :permission => 'view_smart_proxies_puppetca', :authorizer => authorizer, :anchor => 'certificates'))
 
@@ -35,11 +36,11 @@ module SmartProxiesHelper
                                                            merge(:auth_object => proxy, :permission => 'view_smart_proxies_autosign', :authorizer => authorizer, :anchor => 'autosign'))
     end
 
-    if proxy.has_feature?('DHCP')
+    if feature_names.include?('DHCP')
       actions << display_link_if_authorized(_("Import IPv4 subnets"), hash_for_import_subnets_path(:smart_proxy_id => proxy))
     end
 
-    if proxy.has_feature?('Logs')
+    if feature_names.include?('Logs')
       actions << link_to_function_if_authorized(_('Expire logs'), "expireLogs(this, (new Date).getTime() / 1000);",
         hash_for_expire_logs_smart_proxy_path(:id => proxy), {
           :data => {

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -15,7 +15,7 @@
     </tr>
   </thead>
   <tbody>
-    <% for proxy in @smart_proxies %>
+    <% @smart_proxies.each do |proxy| %>
       <tr class="proxy-show" data-url="<%= ping_smart_proxy_path(proxy) %>">
         <td class="nbsp ellipsis"><%= link_to_if_authorized proxy.name, {:action => :show, :id => proxy} %></td>
         <td class="hidden-sm hidden-xs nbsp ellipsis"><%= generate_links_for(proxy.locations).html_safe %></td>


### PR DESCRIPTION
Eliminates N+1 queries on smart proxies index.

Issues were present in the missing controller include, as well as in the helper triggering multiple uncached queries for each table row.