### PR TITLE
Fixes #39586 - Improve RAM consumption for host available errata report; add auto-compression to reports; fix gzip output

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -326,7 +326,7 @@ module Api
     end
 
     def log_response_body
-      logger.debug { "Body: #{response.body}" }
+      logger.debug { "Body: #{response.body}" } unless response.headers['Content-Disposition']&.include?('attachment')
     end
 
     private

--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -189,8 +189,14 @@ module Api
         else
           data = StoredValue.read(params[:job_id])
           return not_found(_('Report data are not available, it has probably expired.')) unless data
-          data = data.to_json if @composer.mime_type == 'application/json'
-          send_data data, type: @composer.mime_type, filename: @composer.report_filename
+          if data.b[0, 2] == "\x1f\x8b".b  # This header indicates the start of a gzip file
+            filename = @composer.report_filename
+            filename += '.gz' unless filename.end_with?('.gz')
+            send_data data, type: 'application/gzip', filename: filename
+          else
+            data = data.to_json if @composer.mime_type == 'application/json'
+            send_data data, type: @composer.mime_type, filename: @composer.report_filename
+          end
         end
       end
 

--- a/app/models/concerns/strip_whitespace.rb
+++ b/app/models/concerns/strip_whitespace.rb
@@ -7,6 +7,7 @@ module StripWhitespace
 
   def strip_spaces
     changes.each do |column, values|
+      next if self.class.columns_hash[column]&.type == :binary
       self[column] = self[column].strip if (self[column].is_a?(String) && !skip_strip_attrs.include?(column))
     end
   end

--- a/app/models/report_composer.rb
+++ b/app/models/report_composer.rb
@@ -239,7 +239,7 @@ class ReportComposer
   def render(mode: Foreman::Renderer::REAL_MODE, **params)
     params[:params] = { :format => format }.merge(params.fetch(:params, {}))
     result = @template.render(mode: mode, template_input_values: template_input_values, **params)
-    result = ActiveSupport::Gzip.compress(result) if gzip?
+    result = ActiveSupport::Gzip.compress(result) if gzip? || result.bytesize > Setting[:report_auto_gzip_threshold].megabytes
     result
   end
 

--- a/app/models/stored_value.rb
+++ b/app/models/stored_value.rb
@@ -13,6 +13,7 @@ class StoredValue < ApplicationRecord
 
   def self.read(result_key)
     record = valid.find_by(key: result_key)
-    record&.value&.force_encoding('UTF-8')
+    return nil unless record&.value
+    record.value.force_encoding('UTF-8')
   end
 end

--- a/app/views/unattended/report_templates/host_-_available_errata.erb
+++ b/app/views/unattended/report_templates/host_-_available_errata.erb
@@ -30,22 +30,32 @@ require:
   version: 4.9.0
 -%>
 <%- report_headers 'Host', 'Operating System', 'Environment', 'Erratum', 'Type', 'Published', 'Available since', 'Severity', 'Packages', 'CVEs', 'Reboot suggested' -%>
-<%- errata_filter = input('Errata filter') %>
-<%- load_hosts(search: input('Hosts filter'), preload: [:operatingsystem]).each_record do |host| -%>
-<%-   (input('Installability') == 'applicable' ? host_applicable_errata_filtered(host, errata_filter) : host_installable_errata_filtered(host, errata_filter)).each do |erratum| -%>
-<%-     report_row(
-          'Host': host.name,
-          'Operating System': host.operatingsystem,
-          'Environment': host.single_lifecycle_environment,
-          'Erratum': erratum.errata_id,
-          'Type': erratum.errata_type,
-          'Published': erratum.issued,
-          'Available since': erratum.created_at,
-          'Severity': erratum.severity,
-          'Packages': erratum.package_names,
-          'CVEs': erratum.cves.map { |c| c.cve_id },
-          'Reboot suggested': erratum.reboot_suggested,
-        ) -%>
+<%- errata_filter = input('Errata filter') -%>
+<%- installability = input('Installability') -%>
+<%# Tune host batch size to match your preferred memory consumption. -%>
+<%# Expect ~1.5KiB consumption per erratum per host. A 500 host batch of 100 errata per host would consume ~73MiB. -%>
+<%- host_batch_size = 500 -%>
+<%- hosts = load_hosts(search: input('Hosts filter'), preload: [:operatingsystem], batch: host_batch_size) -%>
+<%- hosts.each do |host_batch| -%>
+<%-   batch_data = load_errata_and_cves_by_host(host_batch.to_a, installability: installability, errata_filter: errata_filter) -%>
+<%-   errata_by_host = batch_data[:errata_by_host] -%>
+<%-   cves_by_erratum = batch_data[:cves_by_erratum] -%>
+<%-   host_batch.each do |host| -%>
+<%-     (errata_by_host[host.id] || []).each do |erratum| -%>
+<%-       report_row(
+            'Host': host.name,
+            'Operating System': host.operatingsystem,
+            'Environment': host.single_lifecycle_environment,
+            'Erratum': erratum.errata_id,
+            'Type': erratum.errata_type,
+            'Published': erratum.issued,
+            'Available since': erratum.created_at,
+            'Severity': erratum.severity,
+            'Packages': erratum.package_names,
+            'CVEs': cves_by_erratum[erratum.errata_id] || [],
+            'Reboot suggested': erratum.reboot_suggested,
+          ) -%>
+<%-     end -%>
 <%-   end -%>
 <%- end -%>
 <%= report_render -%>

--- a/config/initializers/f_foreman_settings_general.rb
+++ b/config/initializers/f_foreman_settings_general.rb
@@ -104,5 +104,12 @@ Foreman::SettingManager.define(:foreman) do
       description: N_("Foreman will load the new UI for host details"),
       default: true,
       full_name: N_('New host details UI'))
+    setting('report_auto_gzip_threshold',
+      type: :integer,
+      description: N_('Report results above this size (in MiB) are automatically compressed with gzip before storage. Set to 0 to always compress. Maximum value is 512.'),
+      default: 256,
+      full_name: N_('Report auto gzip threshold (MiB)'))
+    validates('report_auto_gzip_threshold', ->(value) { value.is_a?(Integer) && value >= 0 && value <= 512 },
+      message: N_("must be between 0 and 512 MiB"))
   end
 end

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -433,15 +433,15 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
         assert_equal 'plain response', response.body
       end
 
-      it 'return gziped stored_content if job done and has gzip param' do
-        stub_plan_arguments(gzip: true)
-        compressed_value = ActiveSupport::Gzip.compress('plain response')
-        StoredValue.expects('read').with('JOBID').returns(compressed_value)
+      it 'serves compressed report as gzip download' do
+        stub_plan_arguments
+        compressed = ActiveSupport::Gzip.compress('plain response')
+        StoredValue.expects('read').with('JOBID').returns(compressed)
 
         get :report_data, params: { id: report_template.id, job_id: 'JOBID' }
         assert_response :success
         assert_equal 'application/gzip', response.media_type
-        assert_equal compressed_value, response.body
+        assert_equal compressed, response.body
       end
     end
   end

--- a/webpack/assets/javascripts/react_app/components/TemplateGenerator/TemplateGeneratorActions.js
+++ b/webpack/assets/javascripts/react_app/components/TemplateGenerator/TemplateGeneratorActions.js
@@ -50,7 +50,7 @@ const _getErrors = errorResponse => {
 export const pollReportData = pollUrl => dispatch => {
   dispatch({ type: TEMPLATE_GENERATE_POLLING, payload: { url: pollUrl } });
 
-  return API.get(pollUrl, { responseType: 'blob' })
+  return API.get(pollUrl, {}, {}, { responseType: 'blob' })
     .then(response => {
       if (response.status === HTTP_STATUS_CODES.OK) {
         dispatch({ type: TEMPLATE_GENERATE_SUCCESS, payload: {} });

--- a/webpack/assets/javascripts/react_app/components/TemplateGenerator/__tests__/TemplateGeneratorActions.test.js
+++ b/webpack/assets/javascripts/react_app/components/TemplateGenerator/__tests__/TemplateGeneratorActions.test.js
@@ -48,7 +48,7 @@ describe('TemplateGeneratorActions', () => {
       runActionInDepth(() => actions.generateTemplate(), 2).then(callTree => {
         expect(callTree[1][0].type).toEqual(TEMPLATE_GENERATE_POLLING);
         expect(callTree[1][0].payload).toHaveProperty('url', dataUrl);
-        expect(API.get.mock.calls[0]).toEqual([dataUrl, expect.any(Object)]);
+        expect(API.get.mock.calls[0]).toEqual([dataUrl, {}, {}, { responseType: 'blob' }]);
       });
     });
 

--- a/webpack/assets/javascripts/react_app/redux/API/API.js
+++ b/webpack/assets/javascripts/react_app/redux/API/API.js
@@ -12,10 +12,11 @@ axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 axios.defaults.headers.common['X-CSRF-Token'] = getcsrfToken();
 
 export default {
-  get(url, headers = {}, params = {}) {
+  get(url, headers = {}, params = {}, config = {}) {
     return axios.get(foremanUrl(url), {
       headers,
       params,
+      ...config,
     });
   },
   put(url, data = {}, headers = {}) {


### PR DESCRIPTION
This PR requires https://github.com/Katello/katello/pull/11817 to test Katello changes.

**What has changed in this PR:**
- The host available errata report uses a much more efficient lookup system introduced in https://github.com/Katello/katello/pull/11817 which batches hosts and uses joins to determine errata by host and CVEs by errata. This report takes these hashes as input to build it's CSV file.
- Added a setting called `report_auto_gzip_threshold`. Any reports over the set file size will be automatically gzipped. The column supports 1024MiB of data but 512MiB is the upper limit; the column is bytea and uses hex encoding, meaning every byte becomes two chars. Improving this was way out of scope for this PR and hit too many different areas for my comfort.
- Using the GZIP option for reports (`--gzip 1` in hammer) has been fixed for all reports. Previously, if the `.csv.gz` file ended in null chars, they would be stripped upon storing to the database. This is no longer the case. Binary data is no longer stripped in `app/models/concerns/strip_whitespace.rb` **(PLEASE VET THIS PART WELL)**.
- TemplateGeneratorActions passed `responseType: 'blob'` as a header so it didn't actually do anything from what I can tell. This meant file downloads on the report job page were always fully loaded into the browser's memory before being downloaded. Obviously this was an issue for huge files. I've fixed this so that the payload is streamed to disk. **(PLEASE ENSURE THE CHANGES IN `API.js` ARE SAFE)**

**Things to discuss**
- Is 256MiB a decent default for auto-compression? Seems reasonable to me. Excel can't even load all the lines of a 256MiB CSV from this report.
- Removing whitespace stripping from binary data seems okay to me but it is very dangerous. I don't think this impacts anything but please triple check.
- Please ensure the changes in API.js are safe. I had to make this change so that blob data from reports could be downloaded like normal in a browser.

**How to test**
1. Pull this PR and the linked Katello PR.
2. Set up your environment with a host or two that has applicable, installable errata.
3. Run the new "Host - Available Errata" report in applicable and installable modes and ensure the output looks correct.
4. Change report_auto_gzip_threshold to 0MiB. Run report generation again and make sure it downloads a correct .csv.gz file. Change the setting back to default.
6. Repeat steps 3 and 4 with hammer and ensure report generation works as expected.
7. Vet for code quality. Make sure the whitespace and api changes mentioned a few times above are good to go.
8. Check that the unit tests are correct and applicable.
9. Message me for details on a reproducer environment with 5000 hosts with lots of errata. I have it ready to go.