### PR TITLE
Fixes #39590 - Fix LDAP/external usergroups API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -83,8 +83,15 @@ module Api
       association = resource_class.reflect_on_all_associations.detect { |assoc| assoc.plural_name == parent_name.pluralize }
       # if couldn't find an association by name, try to find one by class
       association ||= resource_class.reflect_on_all_associations.detect { |assoc| assoc.class_name == parent_name.camelize }
-      if association.nil? && parent_name == 'host'
-        association = resource_class.reflect_on_all_associations.detect { |assoc| assoc.class_name == 'Host::Base' }
+      # the parent might be an STI subclass (e.g. AuthSourceLdap < AuthSource, Host::Managed < Host::Base)
+      # while the association is declared against the STI base class, so fall back to a subclass check
+      if association.nil?
+        parent_class = resource_class_for(resource_name(parent_name))
+        association = resource_class.reflect_on_all_associations.detect do |assoc|
+          parent_class && !assoc.polymorphic? && parent_class <= assoc.klass
+        rescue NameError
+          false
+        end
       end
       return resource_class.all if association.nil? && Taxonomy.types.include?(resource_class_for(resource_name(parent_name)))
       raise "Association not found for #{parent_name}" unless association

--- a/test/controllers/api/v2/external_usergroups_controller_test.rb
+++ b/test/controllers/api/v2/external_usergroups_controller_test.rb
@@ -13,6 +13,14 @@ class Api::V2::ExternalUsergroupsControllerTest < ActionController::TestCase
     refute_empty ActiveSupport::JSON.decode(@response.body)['results']
   end
 
+  test 'external user groups in auth source ldap' do
+    get :index, params: { auth_source_ldap_id: @external_usergroup.auth_source_id }
+
+    assert_response :success
+    assert_not_nil assigns(:external_usergroups)
+    refute_empty ActiveSupport::JSON.decode(@response.body)['results']
+  end
+
   test 'show an external user group' do
     get :show, params: { :usergroup_id => @external_usergroup.usergroup_id,
                          :id           => @external_usergroup.id }


### PR DESCRIPTION
Fixes parent_scope method in base api controller for all STI subclasses (not just AuthSourceLdap), adds a test case for the LDAP scenario.