### PR TITLE
Fixes #39591 - preserve except options for audits

### DIFF
--- a/app/lib/audit_associations/associations_definitions.rb
+++ b/app/lib/audit_associations/associations_definitions.rb
@@ -1,9 +1,15 @@
 module AuditAssociations
   module AssociationsDefinitions
     def audited(options = {})
+      options = options.dup
       options[:associations] = normalize_associations(options[:associations])
       if options[:associations].present?
         configure_dirty_associations(options[:associations])
+      end
+
+      if audited_already? && association_only_audited_update?(options)
+        audited_options[:associations] = Array(audited_options[:associations]) | options[:associations]
+        return
       end
 
       super
@@ -28,6 +34,19 @@ module AuditAssociations
     def configure_dirty_associations(associations)
       include DirtyAssociations unless included_modules.include?(DirtyAssociations)
       dirty_has_many_associations(*associations)
+    end
+
+    private
+
+    def audited_already?
+      included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
+    end
+
+    # True when the caller only supplied :associations (the pattern used by plugins
+    # to extend association auditing). Explicit :except/:only/:on/etc. still replace.
+    def association_only_audited_update?(options)
+      options[:associations].present? &&
+        (options.keys.map(&:to_sym) - [:associations]).empty?
     end
   end
 end

--- a/test/models/concerns/audit_associations_test.rb
+++ b/test/models/concerns/audit_associations_test.rb
@@ -43,4 +43,19 @@ class AuditAssociationsTest < ActiveSupport::TestCase
     assert_equal [Role.default.id, role.id].sort, audit.audited_changes['role_ids'].sort
     assert_equal 'destroy', audit.action
   end
+
+  test "audited associations-only update preserves existing except options" do
+    except = Host::Managed.audited_options[:except].dup
+    associations = Host::Managed.audited_options[:associations].dup
+
+    Host::Managed.audited :associations => [:pools]
+
+    assert_equal except, Host::Managed.audited_options[:except]
+    assert_includes Host::Managed.audited_options[:associations], 'pool_ids'
+    associations.each do |association|
+      assert_includes Host::Managed.audited_options[:associations], association
+    end
+  ensure
+    Host::Managed.audited_options[:associations] = associations if associations
+  end
 end


### PR DESCRIPTION
context in SAT-46970
previously the except options for audits got overridden when plugins extended the audit associations

summary: updates to `Host::Managed` attributes such as `last_report` were being audited even though the model explicitly excluded them. The source of the problem was not the exclusion list itself, but a change in behavior in the `audited` gem 5.8.0: a second `audited` call no longer had no effect, and instead replaced the model’s audit options. Katello’s `SubscriptionFacetHostExtensions` called `audited :associations => [:pools]` on `Host::Managed` after Foreman had already configured exclusions, which cleared `:except` and left only association auditing (`pool_ids`, `ansible_role_ids`). The fix was made in Foreman’s `AuditAssociations::AssociationsDefinitions#audited`: when a model is already audited and a later call only adds `:associations`, those associations are merged into the existing options instead of replacing them, so `last_report`, `last_compile`, `lookup_value_matcher`, and `global_status` remain excluded while pool association auditing still works.