### PR TITLE
Fixes #39592 - PageLayout set Breadcrums to use PF5 layout

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -59,7 +59,9 @@ const PageLayout = ({
         <PageSection variant={PageSectionVariants.light} type="breadcrumb">
           <div id="breadcrumb">
             {customBreadcrumbs ||
-              (breadcrumbOptions && <BreadcrumbBar {...breadcrumbOptions} />)}
+              (breadcrumbOptions && (
+                <BreadcrumbBar {...breadcrumbOptions} isPf4 />
+              ))}
           </div>
         </PageSection>
       )}


### PR DESCRIPTION
**Description of problem:**

PageLayout component is using PF3 variant of Breadcrumbs which leads to overlapping underline with negative margin which causes site to horizontally overflow


**How reproducible:**

Use upstream version of foreman and open site which uses PageLayout component with Breadcrumbs.

**Example of involved pages:** 
- TaskDetails
- Models
- Add Subscription

Before:
<img width="1829" height="1257" alt="image" src="https://github.com/user-attachments/assets/ad5421aa-e112-4ee0-9c52-583e07542543" />


After:
<img width="1829" height="1257" alt="image" src="https://github.com/user-attachments/assets/0007fc37-6aee-45e4-bf67-4f1f1bbc59b1" />