### PR TITLE
Fixes #39593 - Restore background color for Rails-rendered pages

### DIFF
--- a/app/assets/stylesheets/base-pf4.scss
+++ b/app/assets/stylesheets/base-pf4.scss
@@ -21,6 +21,7 @@ body {
   font-weight: var(--pf-v5-global--FontWeight--normal);
   line-height: var(--pf-v5-global--LineHeight--md);
   text-align: left;
+  --pf-v5-c-page--BackgroundColor: var(--pf-v5-global--BackgroundColor--100);
 }
 
 a {

--- a/webpack/assets/javascripts/react_app/components/Layout/layout.scss
+++ b/webpack/assets/javascripts/react_app/components/Layout/layout.scss
@@ -103,10 +103,6 @@
   }
 }
 
-#foreman-page {
-  --pf-v5-c-page--BackgroundColor: var(--pf-v5-global--BackgroundColor--100);
-}
-
 #foreman-page .pf-v5-c-masthead {
   background-repeat: no-repeat;
   background-size: cover;


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

Commit fb3d37d ("Fixes #39276 - Add Stylelint rule to block global css overrides") changed the selector in layout.scss from .pf-v5-c-page to #foreman-page to comply with the new foreman/no-root-pf-overrides stylelint rule. This inadvertently dropped the --pf-v5-c-page--BackgroundColor override for #rails-app-content, which is the wrapper for Rails-rendered pages in base.html.erb and uses class="pf-v5-c-page" instead of id="foreman-page".

As a result, Rails-rendered pages (used by Foreman and plugins like Katello) no longer inherit the intended background color  (--pf-v5-global--BackgroundColor--100).

Example:
Go to menu -> facts
See the background color difference in empty section.
<img width="1914" height="919" alt="Screenshot from 2026-08-05 14-41-20" src="https://github.com/user-attachments/assets/bb3c4234-3157-4a12-9283-9d7efccfbc45" />

Go to menu > Lifecycle > Content Views
Page renders with this background color:
<img width="1668" height="597" alt="Screenshot from 2026-08-05 14-45-10" src="https://github.com/user-attachments/assets/283b793c-5ad4-4f94-82df-605ef0060468" />


