### PR TITLE
Fixes #39600 - Install libcap-dev for cap2 gem in plugins_react_tests.yml

### DIFF
--- a/.github/workflows/plugins_react_tests.yml
+++ b/.github/workflows/plugins_react_tests.yml
@@ -72,6 +72,8 @@ jobs:
             cat ${{ matrix.plugin.name }}/gemfile.d/*.rb >> bundler.d/${{ matrix.plugin.name }}.local.rb
           fi
         working-directory: ${{ github.workspace }}/projects/foreman
+      - run: sudo apt-get update
+      - run: sudo apt-get -qq -y install libcap-dev
       - name: "Set up Ruby ${{ matrix.ruby }}"
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary
- `net-ping 2.1.0` added a runtime dependency on `cap2`, whose native extension requires `libcap` headers to compile.
- This was already fixed for `foreman.yml` and the `Dockerfile` in #39600, but `plugins_react_tests.yml` runs its own `bundle install` step and was missed, so its CI jobs fail with `sys/capability.h is missing`.
- Adds the same `libcap-dev` apt install used elsewhere in this repo's workflows.

## Test plan
- [ ] Confirm the `(non-blocking) React on plugins` workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)