### PR TITLE
Fixes #39608 - Templates - parse_url helper & URI.hostname

### DIFF
--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -6,6 +6,7 @@ module Foreman
       DEFAULT_ALLOWED_GENERIC_HELPERS = [
         :foreman_url,
         :force_url_https,
+        :parse_url,
         :snippet, :snippets,
         :snippet_if_exists,
         :indent,

--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -462,6 +462,18 @@ module Foreman
             Foreman::Version.new.short
           end
 
+          apipie :method, 'Parses a URL string and returns a URI object' do
+            required :url, String, desc: 'URL string to parse'
+            returns URI::Generic, desc: 'Parsed URI object; use .hostname, .host, .port, .path, .scheme, .query on the result'
+            example "parse_url('https://tower.example.com:443').hostname # => 'tower.example.com'"
+            example "parse_url('https://[::1]').hostname # => '::1'"
+          end
+          def parse_url(url)
+            URI.parse(url.to_s)
+          rescue URI::InvalidURIError
+            URI.parse('')
+          end
+
           private
 
           def validate_subnet(subnet)

--- a/config/initializers/safemode_jail.rb
+++ b/config/initializers/safemode_jail.rb
@@ -17,7 +17,7 @@ class ActiveRecord::Batches::BatchEnumerator::Jail < Safemode::Jail
 end
 
 class URI::Generic::Jail < Safemode::Jail
-  allow :host, :path, :port, :query, :scheme
+  allow :fragment, :host, :hostname, :path, :port, :query, :scheme
 end
 
 class ActiveSupport::TimeWithZone::Jail < Safemode::Jail

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -195,10 +195,35 @@ class BaseMacrosTest < ActiveSupport::TestCase
   end
 
   test 'URI::Generic jail test' do
-    allowed = [:host, :path, :port, :query, :scheme]
+    allowed = [:fragment, :host, :hostname, :path, :port, :query, :scheme]
     allowed.each do |m|
       assert URI::HTTP::Jail.allowed?(m), "Method #{m} is not available in URI::HTTP::Jail while should be allowed."
     end
+  end
+
+  test 'parse_url returns hostname for URL with domain' do
+    result = @scope.parse_url('https://tower.example.com:8443/api/v2')
+    assert_equal 'tower.example.com', result.hostname
+  end
+
+  test 'parse_url returns hostname for URL with IPv4' do
+    result = @scope.parse_url('https://192.168.1.1:8443/api/v2')
+    assert_equal '192.168.1.1', result.hostname
+  end
+
+  test 'parse_url returns hostname for URL with IPv6' do
+    result = @scope.parse_url('https://[::1]:8443/api/v2')
+    assert_equal '::1', result.hostname
+  end
+
+  test 'parse_url handles invalid URL without raising' do
+    result = @scope.parse_url('not a valid url %%')
+    assert_nil result.hostname
+  end
+
+  test 'parse_url handles empty string without raising' do
+    result = @scope.parse_url('')
+    assert_nil result.hostname
   end
 
   context 'subnet helpers' do


### PR DESCRIPTION
New template helper 'parse_url' with 'URI.hostname' added to the safe mode methods


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
