### PR TITLE
Fixes #39610 - Dynamically compute status on host statuses page

### DIFF
--- a/app/models/host_status/build_status.rb
+++ b/app/models/host_status/build_status.rb
@@ -56,6 +56,27 @@ module HostStatus
       end
     end
 
+    def self.computed_status_sql
+      token_expired_clause = if Setting[:token_duration] != 0
+                               "WHEN hosts.build = true AND tokens.id IS NOT NULL AND tokens.expires < CURRENT_TIMESTAMP THEN #{TOKEN_EXPIRED}"
+                             end
+
+      <<~SQL.squish
+        CASE
+          #{token_expired_clause}
+          WHEN hosts.build = true
+          THEN #{PENDING}
+          WHEN hosts.build_errors IS NOT NULL
+          THEN #{BUILD_FAILED}
+          ELSE #{BUILT}
+        END
+      SQL
+    end
+
+    def self.computed_status_joins
+      "LEFT JOIN tokens ON tokens.host_id = #{table_name}.host_id"
+    end
+
     def waiting_for_build?
       host&.build
     end

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -82,5 +82,15 @@ module HostStatus
     def update_status
       self.status = to_status
     end
+
+    def self.computed_status_sql
+      "#{table_name}.status"
+    end
+
+    def self.computed_status_joins
+      nil
+    end
+
+    private_class_method :computed_status_sql, :computed_status_joins
   end
 end

--- a/app/presenters/host_status_presenter.rb
+++ b/app/presenters/host_status_presenter.rb
@@ -111,11 +111,20 @@ class HostStatusPresenter
   private
 
   def total_data
-    status_class.joins(:host).merge(Host.authorized).group(:status).count
+    @total_data ||= begin
+      scope = status_class.joins(:host).merge(Host.authorized)
+      scope = scope.joins(status_class.computed_status_joins) if status_class.computed_status_joins
+      scope.group(Arel.sql(status_class.computed_status_sql)).count
+    end
   end
 
   def owned_data
-    status_class.joins(:host).merge(Host::Managed.authorized.search_for('owner = current_user').reorder('')).group(:status).count
+    @owned_data ||= begin
+      scope = status_class.joins(:host)
+                          .merge(Host::Managed.authorized.search_for('owner = current_user').reorder(''))
+      scope = scope.joins(status_class.computed_status_joins) if status_class.computed_status_joins
+      scope.group(Arel.sql(status_class.computed_status_sql)).count
+    end
   end
 
   def total_queries

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -157,6 +157,29 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       "API should not return stale database column value"
   end
 
+  test "total counts reflect dynamically computed status, not stale DB column" do
+    # Create a host in build mode with a token that will expire
+    host = FactoryBot.create(:host, :managed, :build => true)
+    Setting[:token_duration] = 60 # 60 minutes
+
+    # Create the build status record — at this point, token is fresh → PENDING
+    status = host.get_status(HostStatus::BuildStatus)
+    status.refresh!
+    assert_equal HostStatus::BuildStatus::PENDING, status.reload.status
+
+    # Expire the token by moving time forward
+    host.token.update!(expires: 1.hour.ago)
+
+    # DB column still says PENDING, but computed status should be TOKEN_EXPIRED
+    presenter = HostStatusPresenter.new(HostStatus::BuildStatus)
+    totals = presenter.total
+
+    assert_equal 0, totals.fetch(HostStatus::BuildStatus::PENDING, 0),
+      "Stale PENDING count should be 0"
+    assert_equal 1, totals.fetch(HostStatus::BuildStatus::TOKEN_EXPIRED, 0),
+      "TOKEN_EXPIRED count should reflect current state"
+  end
+
   test "index should show ok status for hosts with recent reports" do
     # Create report within outofsync_interval
     @host.reports.create!(

--- a/test/models/host_status/build_status_test.rb
+++ b/test/models/host_status/build_status_test.rb
@@ -44,4 +44,75 @@ class BuildStatusTest < ActiveSupport::TestCase
     @status.host = nil
     refute @status.waiting_for_build?
   end
+
+  # Helper to evaluate computed_status_sql for a single host via the database
+  def sql_status_for(host)
+    HostStatus::BuildStatus
+      .joins(:host)
+      .joins(HostStatus::BuildStatus.computed_status_joins)
+      .where(host_id: host.id)
+      .pick(Arel.sql(HostStatus::BuildStatus.computed_status_sql))
+  end
+
+  test 'to_status and computed_status_sql agree when token_duration is 0 and expired token exists' do
+    Setting[:token_duration] = 30
+    host = FactoryBot.create(:host, :managed, :build => true)
+    host.set_token
+    host.save!
+    host.token.update!(expires: 1.hour.ago)
+    Setting[:token_duration] = 0
+
+    status = HostStatus::BuildStatus.find_by(host_id: host.id) || HostStatus::BuildStatus.create!(host: host)
+    assert_equal status.to_status, sql_status_for(host),
+      'Ruby and SQL should both return PENDING when token_duration is 0, even with an expired token'
+  end
+
+  test 'to_status and computed_status_sql agree when token_duration is nonzero and token is expired' do
+    Setting[:token_duration] = 30
+    host = FactoryBot.create(:host, :managed, :build => true)
+    host.set_token
+    host.save!
+    host.token.update!(expires: 1.hour.ago)
+
+    status = HostStatus::BuildStatus.find_by(host_id: host.id) || HostStatus::BuildStatus.create!(host: host)
+    assert_equal HostStatus::BuildStatus::TOKEN_EXPIRED, status.to_status
+    assert_equal status.to_status, sql_status_for(host)
+  end
+
+  test 'to_status and computed_status_sql agree when host is building with no token' do
+    Setting[:token_duration] = 0
+    host = FactoryBot.create(:host, :managed, :build => true)
+
+    status = HostStatus::BuildStatus.find_by(host_id: host.id) || HostStatus::BuildStatus.create!(host: host)
+    assert_equal HostStatus::BuildStatus::PENDING, status.to_status
+    assert_equal status.to_status, sql_status_for(host)
+  end
+
+  test 'to_status and computed_status_sql agree when host is building with valid token' do
+    Setting[:token_duration] = 30
+    host = FactoryBot.create(:host, :managed, :build => true)
+    host.set_token
+    host.save!
+
+    status = HostStatus::BuildStatus.find_by(host_id: host.id) || HostStatus::BuildStatus.create!(host: host)
+    assert_equal HostStatus::BuildStatus::PENDING, status.to_status
+    assert_equal status.to_status, sql_status_for(host)
+  end
+
+  test 'to_status and computed_status_sql agree when host is built' do
+    host = FactoryBot.create(:host, :managed, :build => false)
+
+    status = HostStatus::BuildStatus.find_by(host_id: host.id) || HostStatus::BuildStatus.create!(host: host)
+    assert_equal HostStatus::BuildStatus::BUILT, status.to_status
+    assert_equal status.to_status, sql_status_for(host)
+  end
+
+  test 'to_status and computed_status_sql agree when host has build errors' do
+    host = FactoryBot.create(:host, :managed, :build => false)
+    host.update_column(:build_errors, 'something went wrong')
+
+    status = HostStatus::BuildStatus.find_by(host_id: host.id) || HostStatus::BuildStatus.create!(host: host)
+    assert_equal HostStatus::BuildStatus::BUILD_FAILED, status.to_status
+    assert_equal status.to_status, sql_status_for(host)
+  end
 end


### PR DESCRIPTION
The issue fixed in https://github.com/theforeman/foreman/pull/10962 and https://github.com/theforeman/foreman/pull/10993 for the All Hosts page also occurs on the Host Statuses page. When the build status of a host changes, the change is not reflected in the counts on the Host Statuses page, although it is reflected on the All Hosts and Host Details pages.

This PR ensures that build status aggregates displayed on the Host Statuses page are computed dynamically instead of read from a potentially stale database column. The approach here differs from the PRs linked above due to performance considerations. That approach applied to the Host Statuses page would require trading a single aggregate SQL query for loading all status records into memory. This could potentially cause performance issues in Foreman instances with very large host footprints or very heavy host deployment churn. Instead, the approach here adds an SQL expression to the BuildStatus class that mirrors its to_status logic so the aggregate is read from the computed value rather than the raw column. 

Testing Steps:
1. On the Administer > Settings page > Provisioning tab, set the `Installation token lifetime` setting to a small value, such as 1 minute.
2. Configure any repositories and provisioning resources needed to create a new host.
3. Create a host using the form on the Hosts > Create Host page.
4. Put the host in build mode.
5. Navigate to the Monitor > Host Statuses page and verify that the Total and Owned counts in OK (green checkmark) column have been incremented by 1.
6. Wait for the installation token to expire.
7. Refresh the Monitor > Host Statuses page.

Expected Results:
The Total and Owned counts in the OK column have been decremented by 1 and the Total and Owned counts in the Error column have been incremented by 1.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
