### PR TITLE
Fixes #39626 - Recover gracefully from concurrent create races on Subnet and Operatingsystem

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -191,6 +191,15 @@ module Api
       end
     end
 
+    def process_create_with_record_not_unique(resource)
+      process_response resource.save
+    rescue ActiveRecord::RecordNotUnique
+      recovered_resource = yield(resource)
+      raise unless recovered_resource
+
+      process_success recovered_resource
+    end
+
     def render_message(msg, render_options = {})
       render_options[:json] = { :message => msg }
       render render_options

--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -64,7 +64,13 @@ module Api
 
       def create
         @operatingsystem = Operatingsystem.new(operatingsystem_params)
-        process_response @operatingsystem.save
+        process_create_with_record_not_unique(@operatingsystem) do |operatingsystem|
+          @operatingsystem = Operatingsystem.find_by(
+            name: operatingsystem.name,
+            major: operatingsystem.major,
+            minor: operatingsystem.minor
+          )
+        end
       end
 
       api :PUT, "/operatingsystems/:id/", N_("Update an operating system")

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -63,7 +63,9 @@ module Api
 
       def create
         @subnet = Subnet.new_network_type(subnet_params)
-        process_response @subnet.save
+        process_create_with_record_not_unique(@subnet) do |subnet|
+          @subnet = Subnet.unscoped.find_by(name: subnet.name)
+        end
       end
 
       api :PUT, '/subnets/:id', N_("Update a subnet")

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -73,7 +73,14 @@ module Api::V2::TaxonomiesController
   def create
     @taxonomy = taxonomy_class.new(resource_params)
     instance_variable_set("@#{taxonomy_single}", @taxonomy)
-    process_response @taxonomy.save
+    process_create_with_record_not_unique(@taxonomy) do |taxonomy|
+      @taxonomy = taxonomy_class.unscoped
+        .where(type: taxonomy.type, ancestry: taxonomy.ancestry)
+        .where('LOWER(name) = ?', taxonomy.name.to_s.downcase)
+        .first
+      instance_variable_set("@#{taxonomy_single}", @taxonomy)
+      @taxonomy
+    end
   end
 
   api :PUT, '/:resource_id/:id', N_('Update :a_resource')

--- a/db/migrate/20260814125426_enforce_unique_taxonomies.rb
+++ b/db/migrate/20260814125426_enforce_unique_taxonomies.rb
@@ -1,0 +1,33 @@
+class EnforceUniqueTaxonomies < ActiveRecord::Migration[7.0]
+  def up
+    # Concurrent creates can race past the model-level uniqueness check and
+    # insert duplicates. Abort and list them rather than guessing at a merge -
+    # raced rows can carry real associations (hosts, children, parameters...).
+    duplicate_keys = Taxonomy.unscoped
+      .group(:type, :ancestry, Arel.sql('LOWER(name)'))
+      .having('count(*) > 1')
+      .pluck(:type, :ancestry, Arel.sql('LOWER(name)'))
+
+    if duplicate_keys.any?
+      details = duplicate_keys.map do |type, ancestry, lower_name|
+        ids = Taxonomy.unscoped
+          .where(:type => type, :ancestry => ancestry)
+          .where('LOWER(name) = ?', lower_name)
+          .order(:id)
+          .pluck(:id)
+        "  #{type} #{lower_name.inspect} (ancestry=#{ancestry.inspect}) ids=#{ids.join(', ')}"
+      end
+      raise "Cannot add unique index on taxonomies; duplicate names exist. " \
+        "Delete extra rows and re-run:\n#{details.join("\n")}"
+    end
+
+    # ancestry is nullable, and a plain UNIQUE index treats every NULL as
+    # distinct, so COALESCE it to match the existing Rails-level validation.
+    add_index :taxonomies, "type, COALESCE(ancestry, ''), lower(name)", :unique => true,
+      :name => 'index_taxonomies_on_type_ancestry_lower_name'
+  end
+
+  def down
+    remove_index :taxonomies, :name => 'index_taxonomies_on_type_ancestry_lower_name'
+  end
+end

--- a/test/controllers/api/v2/locations_controller_test.rb
+++ b/test/controllers/api/v2/locations_controller_test.rb
@@ -44,6 +44,18 @@ class Api::V2::LocationsControllerTest < ActionController::TestCase
     assert !show_response.empty?
   end
 
+  test "should return existing location when create races on unique name" do
+    existing_location = FactoryBot.create(:location, :name => "Race Location")
+    Location.any_instance.stubs(:save).raises(ActiveRecord::RecordNotUnique)
+
+    assert_difference('Location.unscoped.count', 0) do
+      post :create, params: { :location => { :name => existing_location.name } }
+    end
+
+    assert_response :created
+    assert_equal existing_location.id, JSON.parse(response.body)['id']
+  end
+
   test "should create location with parent" do
     parent_id = Location.first.id
     post :create, params: { :location => { :name => "Test Location", :parent_id => parent_id } }

--- a/test/controllers/api/v2/operatingsystems_controller_test.rb
+++ b/test/controllers/api/v2/operatingsystems_controller_test.rb
@@ -36,6 +36,18 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:operatingsystem)
   end
 
+  test "should return existing os when create races on unique version" do
+    existing_os = FactoryBot.create(:operatingsystem, :name => 'RaceOS', :major => '9', :minor => '1')
+    Operatingsystem.any_instance.stubs(:save).raises(ActiveRecord::RecordNotUnique)
+
+    assert_difference('Operatingsystem.count', 0) do
+      post :create, params: { :operatingsystem => { :name => existing_os.name, :major => existing_os.major, :minor => existing_os.minor } }
+    end
+
+    assert_response :created
+    assert_equal existing_os.id, JSON.parse(response.body)['id']
+  end
+
   test "should create os with name and major version only" do
     os_params = minimum_required_os_params
     assert_difference('Operatingsystem.count') do

--- a/test/controllers/api/v2/subnets_controller_test.rb
+++ b/test/controllers/api/v2/subnets_controller_test.rb
@@ -26,6 +26,18 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
     assert_response :created
   end
 
+  test "should return existing subnet when create races on unique name" do
+    existing_subnet = FactoryBot.create(:subnet_ipv4, :name => valid_v4_attrs[:name])
+    Subnet::Ipv4.any_instance.stubs(:save).raises(ActiveRecord::RecordNotUnique)
+
+    assert_difference('Subnet.unscoped.count', 0) do
+      post :create, params: { :subnet => valid_v4_attrs }
+    end
+
+    assert_response :created
+    assert_equal existing_subnet.id, JSON.parse(response.body)['id']
+  end
+
   test "should create IPv4 subnet if type is not defined" do
     assert_difference('Subnet.unscoped.count') do
       post :create, params: { :subnet => valid_v4_attrs.reject { |k, v| k == :network_type } }

--- a/test/migrate/enforce_unique_taxonomies_test.rb
+++ b/test/migrate/enforce_unique_taxonomies_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+require Rails.root.join('db/migrate/20260814125426_enforce_unique_taxonomies.rb')
+
+class EnforceUniqueTaxonomiesTest < ActiveSupport::TestCase
+  let(:migration) { EnforceUniqueTaxonomies.new }
+
+  setup do
+    # CI runs db:migrate before the suite, so this migration's unique index
+    # already exists. Drop it so migration.up sees the pre-migration state.
+    ActiveRecord::Base.connection.remove_index(:taxonomies, :name => 'index_taxonomies_on_type_ancestry_lower_name')
+  end
+
+  def duplicate_location(name)
+    location = Location.new(:name => name)
+    location.save(:validate => false)
+    location
+  end
+
+  test "adds a unique index that rejects further duplicates" do
+    migration.up
+
+    location = duplicate_location('Post-migration Location')
+    duplicate = Location.new(:name => location.name)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      duplicate.save(:validate => false)
+    end
+  end
+
+  test "aborts when duplicate names already exist, without deleting them" do
+    first = duplicate_location('Race Location')
+    second = duplicate_location('Race Location')
+
+    error = assert_raises(RuntimeError) { migration.up }
+    assert_match(/ids=#{first.id}, #{second.id}/, error.message)
+    assert Location.exists?(id: first.id)
+    assert Location.exists?(id: second.id)
+    assert_not ActiveRecord::Base.connection.index_exists?(:taxonomies, name: 'index_taxonomies_on_type_ancestry_lower_name')
+  end
+
+  test "migration is reversible" do
+    migration.up
+    migration.down
+
+    location = duplicate_location('Post-rollback Location')
+    duplicate = Location.new(:name => location.name)
+
+    assert_nothing_raised do
+      duplicate.save(:validate => false)
+    end
+  end
+end

--- a/test/models/taxonomy_test.rb
+++ b/test/models/taxonomy_test.rb
@@ -4,6 +4,19 @@ class TaxonomyTest < ActiveSupport::TestCase
   should validate_presence_of(:name)
   should validate_uniqueness_of(:name).scoped_to(:ancestry, :type).case_insensitive
 
+  test 'raises ActiveRecord::RecordNotUnique at the DB level when validations are bypassed' do
+    # The validation above is app-level only and can't stop two concurrent
+    # requests from both passing it before either commits; this proves the
+    # DB-level unique index backs it up too, including for top-level (nil
+    # ancestry) records, where a naive index would not.
+    location = FactoryBot.create(:location, :name => 'Race Location DB Test')
+    duplicate = Location.new(:name => location.name)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      duplicate.save(:validate => false)
+    end
+  end
+
   test 'expand return [] for admin if no taxonomy set' do
     as_admin do
       assert_empty Taxonomy.expand(nil)


### PR DESCRIPTION
## Summary

`Subnet` (unique index on `name` since `20180806151925`) and `Operatingsystem` (unique index on `name`+`major`+`minor` since `20150713143226`) both already have real DB-level uniqueness constraints, but their controllers' `create` actions never handled the `ActiveRecord::RecordNotUnique` a concurrent duplicate create raises — it surfaced as a raw 500 instead of the graceful "return the existing record" behavior a client would expect from a race on an idempotent-looking create call.

Fixes #39626.

## Changes

Wires both into the `process_create_with_record_not_unique` helper introduced in #11160 for `Taxonomy`, matching the exact same pattern. No schema changes needed here — these two already had the DB constraint the recovery path depends on, unlike `Taxonomy`.

**Stacked on #11160** — this branch is based on top of it (needs `process_create_with_record_not_unique` in `Api::BaseController`). Please review/merge #11160 first.

## Testing done

Live-verified against the same real Satellite 6.19/foreman-3.18 instance used for #11160 (patched both controller files, restarted the service):
- Concurrent identical `POST /api/subnets`: 4/5 requests returned `201` with the same id (the 5th got the pre-existing, unaffected `422` "already taken" from the normal validation path — the recovery is additive, not a replacement). DB confirmed exactly one row.
- Concurrent identical `POST /api/operatingsystems`: 3/5 returned `201` with the same id, 2/5 got the normal `422`. DB confirmed exactly one row.

Ruby syntax-checked all changed files locally. Same caveat as #11160 - wasn't able to run the full Rails test suite locally (no local Postgres set up), relying on CI plus the live verification above.
