### PR TITLE
Fixes #39627 - Support OpenVox Agent for FreeBSD

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -31,7 +31,7 @@ else
 end
 
 if os_family == 'Freebsd'
-  freebsd_package = host_param_true?('enable-puppet6') ? 'puppet6' : 'puppet8'
+  freebsd_package = host_param_true?('enable-puppet8') ? 'puppet8' : 'openvox-agent8'
   etc_path = '/usr/local/etc/puppet'
   bin_path = '/usr/local/bin'
 elsif os_family == 'Windows'
@@ -119,7 +119,7 @@ puppet_unit=puppet
 <% end -%>
 <% end -%>
 <% if os_family == 'Freebsd' -%>
-echo 'puppet_enable="YES"' >>/etc/rc.conf
+sysrc puppet_enable=YES
 <% end -%>
 <% unless aio_enabled || aio_openvox_enabled -%>
 <% if os_family == 'Debian' -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.freebsd4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.freebsd4dhcp.snap.txt
@@ -24,7 +24,7 @@ pkg update > /root/install/pkg_update.txt
 pkg upgrade -y > /root/install/pkg_upgrade.txt
 
 
-pkg install -y puppet8
+pkg install -y openvox-agent8
 
 cat > /usr/local/etc/puppet/puppet.conf << EOF
 [main]
@@ -41,7 +41,7 @@ certname        = snapshot-ipv4-dhcp-freebsd
 EOF
 
 
-echo 'puppet_enable="YES"' >>/etc/rc.conf
+sysrc puppet_enable=YES
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true


### PR DESCRIPTION
This changes from puppet 5 (default) or puppet 6 (parameter) to openvox 8 (default) or puppet 8 (parameter).

Additionally this moves from writing to an rc.conf file to using the sysrc utility when setting up the agent to run as a service.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
