### PR TITLE
Fixes #39629 - Test FreeBSD (mfsBSD) templates against a FreeBSD host

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -162,6 +162,13 @@ module Foreman
       define_host_params(host)
     end
 
+    def freebsd4dhcp
+      host = FactoryBot.build(:host_for_snapshots, :with_freebsd,
+        name: 'snapshot-ipv4-dhcp-freebsd',
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
+      define_host_params(host)
+    end
+
     def windows10_dhcp
       host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_windows10,
         name: 'snapshot-ipv4-dhcp-windows10',

--- a/app/views/unattended/provisioning_templates/PXELinux/freebsd_(mfsbsd)_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/freebsd_(mfsbsd)_pxelinux.erb
@@ -4,6 +4,8 @@ name: FreeBSD (mfsBSD) PXELinux
 model: ProvisioningTemplate
 oses:
 - FreeBSD
+test_on:
+- freebsd4dhcp
 description: |
   The template to render PXELinux bootloader configuration for FreeBSD.
   The output is deployed on the host's subnet TFTP proxy.

--- a/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
@@ -4,6 +4,8 @@ name: FreeBSD (mfsBSD) finish
 model: ProvisioningTemplate
 oses:
 - FreeBSD
+test_on:
+- freebsd4dhcp
 description: |
   A finish template executed at the end of network provisioning or
   after the image based provisioning is done using the image without user data.

--- a/app/views/unattended/provisioning_templates/provision/freebsd_(mfsbsd)_provision.erb
+++ b/app/views/unattended/provisioning_templates/provision/freebsd_(mfsbsd)_provision.erb
@@ -4,6 +4,8 @@ name: FreeBSD (mfsBSD) provision
 model: ProvisioningTemplate
 oses:
 - FreeBSD
+test_on:
+- freebsd4dhcp
 description: |
   Provisioning template for the FreeBSD.
   It prepares the environment and deploys and runs the Finish template.

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -71,6 +71,12 @@ FactoryBot.define do
       layout { "select disk 0\nclean\nconvert gpt\ncreate partition efi size=200\nformat quick fs=fat32 label=\"System\"\nassign letter=\"S\"\ncreate partition msr size=16\ncreate partition primary\nformat quick fs=ntfs label=\"Windows\"\nassign letter=\"W\"\nlist volume\nexit" }
       os_family { 'Windows' }
     end
+
+    trait :freebsd do
+      sequence(:name) { |n| "freebsd default#{n}" }
+      layout { "# Not supported with zfsinstall" }
+      os_family { 'Freebsd' }
+    end
   end
 
   factory :parameter do
@@ -404,6 +410,10 @@ FactoryBot.define do
 
       trait :with_rocky10 do
         operatingsystem { FactoryBot.build(:for_snapshots_rocky10) }
+      end
+
+      trait :with_freebsd do
+        operatingsystem { FactoryBot.build(:for_snapshots_freebsd) }
       end
 
       factory :host_for_snapshots_ipv4_dhcp_windows10 do

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -286,6 +286,17 @@ FactoryBot.define do
       ptables { [FactoryBot.build(:ptable, name: 'ptable')] }
     end
 
+    factory :for_snapshots_freebsd, class: Freebsd do
+      name { 'FreeBSD' }
+      major { '11' }
+      minor { '2' }
+      type { 'Freebsd' }
+      title { 'FreeBSD 11.2' }
+      architectures { [FactoryBot.build(:architecture, :for_snapshots_x86_64)] }
+      media { [FactoryBot.build(:medium, :freebsd)] }
+      ptables { [FactoryBot.build(:ptable, :freebsd, name: 'ptable')] }
+    end
+
     factory :for_snapshots_windows10, class: Windows do
       name { 'Windows' }
       major { '10' }

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/FreeBSD_(mfsBSD)_PXELinux.freebsd4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/FreeBSD_(mfsBSD)_PXELinux.freebsd4dhcp.snap.txt
@@ -3,4 +3,4 @@ DEFAULT freebsd
 
 LABEL freebsd
     KERNEL memdisk
-    APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img harddisk raw
+    APPEND initrd=boot/FreeBSD-x86_64-11.2-mfs.img harddisk raw

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.freebsd4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.freebsd4dhcp.snap.txt
@@ -1,7 +1,7 @@
 
 /bin/echo '$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0' | pw usermod root -H 0
 cat >> /etc/rc.conf <<EOF
-hostname="snapshot-ipv4-dhcp-el7"
+hostname="snapshot-ipv4-dhcp-freebsd"
 sshd_enable="YES"
 ntpd_enable="YES"
 EOF
@@ -10,7 +10,7 @@ echo ifconfig_`ifconfig -l | cut -d ' ' -f 1`=DHCP >>/etc/rc.conf
 
 echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
 
-/bin/hostname snapshot-ipv4-dhcp-el7
+/bin/hostname snapshot-ipv4-dhcp-freebsd
 cp /usr/share/zoneinfo/UTC /etc/localtime
 adjkerntz -a
 ntpdate first.ntp.server
@@ -24,15 +24,11 @@ pkg update > /root/install/pkg_update.txt
 pkg upgrade -y > /root/install/pkg_upgrade.txt
 
 
-if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
-else
-  yum -t -y install puppet
-fi
+pkg install -y puppet5
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /usr/local/etc/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
+vardir = /var/puppet
 logdir = /var/log/puppet
 rundir = /var/run/puppet
 ssldir = \$vardir/ssl
@@ -40,14 +36,12 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-ipv4-dhcp-freebsd
 
 EOF
 
 
-puppet_unit=puppet
-/usr/bin/systemctl list-unit-files | grep -q puppetagent && puppet_unit=puppetagent
-/usr/bin/systemctl enable ${puppet_unit}
+echo 'puppet_enable="YES"' >>/etc/rc.conf
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
@@ -55,7 +49,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/local/bin/puppet agent --config /usr/local/etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/FreeBSD_(mfsBSD)_provision.freebsd4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/FreeBSD_(mfsBSD)_provision.freebsd4dhcp.snap.txt
@@ -6,7 +6,7 @@ first_disk="`echo ${disk_layout##*[1-9]} | /usr/bin/cut -d' ' -f1`"
 test -z "$first_disk" || echo "First disk: $first_disk"
 
 /root/bin/destroygeom -d $first_disk || exit 1
-/root/bin/zfsinstall -d $first_disk -s 2G -u url --url http://mirror.centos.org/centos/7/os/x86_64 || exit 1
+/root/bin/zfsinstall -d $first_disk -s 2G -u http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/11.2-RELEASE || exit 1
 
 cp /etc/resolv.conf /mnt/etc/resolv.conf
 mount -t devfs devfs /mnt/dev


### PR DESCRIPTION
The FreeBSD/mfsBSD provisioning templates were rendered in snapshot tests against the default fake host, which uses CentOS 7. Add a FreeBSD snapshot factory and host builder, and point the templates at it via the existing test_on template metadata attribute.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
