### PR TITLE
Fixes #39595 - Fix fact value autocomplete for non-admins

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -106,7 +106,10 @@ module Authorizable
     end
 
     def completer_scope(_options)
-      authorized(find_permission_name(:view))
+      authorized_scope = authorized(find_permission_name(:view))
+      return authorized_scope unless authorized_scope.eager_loading?
+
+      where(primary_key => authorized_scope.select(arel_table[primary_key]))
     end
   end
 end

--- a/test/controllers/fact_values_controller_test.rb
+++ b/test/controllers/fact_values_controller_test.rb
@@ -27,6 +27,20 @@ class FactValuesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'non-admin can auto-complete fact values' do
+    setup_user('view', 'facts') do |user|
+      user.organizations = [host.organization]
+      user.locations = [host.location]
+    end
+
+    get :auto_complete_search,
+      params: { :search => "facts.#{fact_name.name} =" },
+      session: set_session_user(@one)
+
+    assert_response :success
+    assert_includes response.body, fact_value.value
+  end
+
   test 'when host-id is presented in params, it should be added to search with "and" operator' do
     get :index, params: {host_id: host.id, search: 'location = a'}, session: set_session_user
     assert_response :success

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -38,6 +38,23 @@ class HostsControllerTest < ActionController::TestCase
     assert_template 'index'
   end
 
+  test "non-admin can auto-complete fact values" do
+    fact_name = FactoryBot.create(:fact_name, :name => 'apt_has_updates')
+    FactoryBot.create(:fact_value, :fact_name => fact_name, :host => @host, :value => 'true')
+    setup_user('view', 'hosts') do |user|
+      user.organizations = [@host.organization]
+      user.locations = [@host.location]
+    end
+    setup_user('view', 'facts')
+
+    get :auto_complete_search,
+      params: { :search => "facts.#{fact_name.name} =" },
+      session: set_session_user(@one)
+
+    assert_response :success
+    assert_includes response.body, 'true'
+  end
+
   test "should get csv index with data" do
     User.current.table_preferences.create(name: 'hosts', columns: ['name', 'os_title', 'model', 'owner', 'hostgroup', 'last_report'])
     host = FactoryBot.create(:host, :with_model, :with_hostgroup, :with_reports)


### PR DESCRIPTION
## Summary

Fixes [#39595](https://projects.theforeman.org/issues/39595).

Fact value autocomplete returned HTTP 500 for non-admin users. Authorization adds eager-loaded taxonomy associations to the `FactValue` scope, while scoped-search selects only the value column. Active Record then tried to instantiate the eager-loaded host without `host_id` and raised `ActiveModel::MissingAttributeError`.

Keep the authorization conditions in a primary-key subquery when a completer scope uses eager loading. The outer autocomplete query can then select only the requested value without instantiating incomplete association records. Authorized scopes without eager loading remain unchanged.

Regression tests cover both affected endpoints:

- host search completion for `facts.<name> =`
- fact value search completion for `facts.<name> =`

## Testing

- Ruby syntax checks pass for all changed files
- RuboCop passes for all changed files
- Regression tests are included for both controller paths

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
