### PR TITLE
Fixes #39596 - Render zero-valued settings correctly

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingRecords/__tests__/SettingRecords.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/SettingRecords/__tests__/SettingRecords.fixtures.js
@@ -257,6 +257,9 @@ export const arraySetting = settings.find(
 export const stringSetting = settings.find(
   item => item.name === 'email_reply_address'
 );
+export const integerSetting = settings.find(
+  item => item.name === 'bcrypt_cost'
+);
 export const timezoneSetting = settings.find(
   item => item.name === 'default_timezone'
 );

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js
@@ -93,8 +93,11 @@ const formatArray = (attr, setting) => {
 const formatTextValue = setting => setting.value;
 const formatTextDefault = setting => setting.default;
 
+export const isEmptyValue = value =>
+  value === null || value === undefined || value === '';
+
 const formatEmpty = (attr, emptyValue, setting) => {
-  if (!setting[attr]) {
+  if (isEmptyValue(setting[attr])) {
     return emptyValue;
   }
   return null;
@@ -112,7 +115,7 @@ const formatArraySelectionValue = setting =>
 const formatArraySelection = (attr, setting) => {
   const selectValues = arraySelection(setting);
 
-  if (!setting[attr] || !selectValues) {
+  if (isEmptyValue(setting[attr]) || !selectValues) {
     return null;
   }
 

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/__tests__/SettingsTableHelpers.test.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/__tests__/SettingsTableHelpers.test.js
@@ -9,6 +9,7 @@ import {
   withHashSelection,
   boolSetting,
   arraySetting,
+  integerSetting,
   timezoneSetting,
   httpProxySetting,
 } from '../../SettingRecords/__tests__/SettingRecords.fixtures';
@@ -59,6 +60,18 @@ describe('SettingsTableHelpers', () => {
     it('should correctly format empty value', () =>
       expect(valueToString({ default: 'random', value: null })).toBe('Empty'));
 
+    it('should correctly format zero value', () =>
+      expect(valueToString({ ...integerSetting, value: 0 })).toBe(0));
+
+    it('should correctly format zero array selection value', () =>
+      expect(
+        valueToString({
+          ...integerSetting,
+          value: 0,
+          selectValues: [{ label: 'Disabled', value: 0 }],
+        })
+      ).toBe('Disabled'));
+
     it('should correctly format text value', () =>
       expect(valueToString({ default: 'random', value: 'value' })).toBe(
         'value'
@@ -83,6 +96,9 @@ describe('SettingsTableHelpers', () => {
       expect(defaultToString({ default: null, value: 'random' })).toBe(
         'Not set'
       ));
+
+    it('should correctly format zero value', () =>
+      expect(defaultToString({ ...integerSetting, default: 0 })).toBe(0));
 
     it('should correctly format text value', () =>
       expect(defaultToString({ default: 'random', value: 'value' })).toBe(

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValue.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValue.js
@@ -5,6 +5,7 @@ import {
   hasDefault,
   withTooltip,
   defaultToString,
+  isEmptyValue,
   valueToString,
 } from '../SettingsTableHelpers';
 
@@ -12,11 +13,7 @@ const innerCell = props => {
   const { setting } = props;
 
   let field = (
-    <div
-      className={
-        setting.value || setting.settingsType === 'boolean' ? '' : 'empty-value'
-      }
-    >
+    <div className={isEmptyValue(setting.value) ? 'empty-value' : ''}>
       {valueToString(setting)}
     </div>
   );

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/SettingValue.test.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/SettingValue.test.js
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
 import {
+  integerSetting,
   rootPass,
   stringSetting,
   withoutFullName,
@@ -82,5 +83,17 @@ describe('SettingValue', () => {
     );
 
     expect(screen.getByText('Empty')).toBeInTheDocument();
+  });
+
+  it('renders zero as a non-empty value', () => {
+    render(<SettingValue setting={{ ...integerSetting, value: 0 }} />);
+
+    expect(screen.getByText('0')).not.toHaveClass('empty-value');
+  });
+
+  it('marks a null value as empty', () => {
+    render(<SettingValue setting={{ ...integerSetting, value: null }} />);
+
+    expect(screen.getByText('Empty')).toHaveClass('empty-value');
   });
 });


### PR DESCRIPTION
## Summary

JavaScript truthiness checks treated the numeric value 0 as an empty setting. As a result, integer settings set to zero were displayed as Empty, their zero defaults were displayed as Not set, and the rendered value retained the empty-value styling.

This change:

- distinguishes null, undefined, and empty strings from valid falsy values
- preserves zero while formatting setting values, defaults, and array-backed selections
- applies empty-value styling only to genuinely empty values
- adds regression coverage based on the existing integer setting fixture

## Testing

- targeted SettingsTable helper and component tests: 22 tests passed
- ESLint on the changed source files
- Prettier check on all changed JavaScript files

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an Assisted-By trailer.