### PR TITLE
Fixes #39638 - Fix host re-registration

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -128,7 +128,7 @@ module Foreman::Controller::Registration
     names = ['host_registration_insights', 'host_registration_remote_execution',
              'host_packages', 'host_update_packages']
 
-    HostParameter.where(host: @host, name: names).destroy_all
+    @host.host_parameters.where(name: names).destroy_all
   end
 
   def setup_host_param(name, value, key_type = 'boolean')
@@ -140,7 +140,7 @@ module Foreman::Controller::Registration
                  value
                end
 
-    HostParameter.create(host: @host, name: name, value: hp_value, key_type: key_type)
+    @host.host_parameters.build(name: name, value: hp_value, key_type: key_type)
   end
 
   def api_authorization_token


### PR DESCRIPTION
Direct `HostParameter` queries bypass the host's association cache, causing stale data when re-registering already registered host. Use `@host.host_parameters` instead to keep the association in sync.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->