### PR TITLE
Fixes #39394 - Handle empty taxonomy scopes in authorizer

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -121,18 +121,25 @@ class Filter < ApplicationRecord
   def search_condition_for_user(user)
     return search_condition unless granular?
 
-    parts = [search]
-    parts += taxonomy_search_condition_for_user(user, taxonomy_search)
-    QueryBuilder.join('AND', parts)
+    taxonomy_conditions = taxonomy_search_condition_for_user(user, taxonomy_search)
+    return false unless taxonomy_conditions
+
+    QueryBuilder.join('AND', [search] + taxonomy_conditions)
   end
 
   def taxonomy_search_condition_for_user(user, search = nil)
     parts = []
     if resource_taxable_by_organization?
-      parts << merge_taxonomy_search('organization_id', search, user.organization_and_child_ids)
+      condition = merge_taxonomy_search('organization_id', search, user.organization_and_child_ids)
+      return false unless condition
+
+      parts << condition
     end
     if resource_taxable_by_location?
-      parts << merge_taxonomy_search('location_id', search, user.location_and_child_ids)
+      condition = merge_taxonomy_search('location_id', search, user.location_and_child_ids)
+      return false unless condition
+
+      parts << condition
     end
     parts
   end
@@ -143,7 +150,9 @@ class Filter < ApplicationRecord
           else
             search.scan(/\d+/).map(&:to_i) & user_ids
           end
-    QueryBuilder.key_value_in(key, ids, :block)
+    return false if ids.empty?
+
+    QueryBuilder.key_value_in(key, ids)
   end
 
   def expire_topbar_cache

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -103,6 +103,11 @@ class Authorizer
     result[:where] << { id: base_ids } if @base_collection.present?
 
     search_string = build_scoped_search_condition(all_filters)
+    # A blank search is unrestricted, while false means the taxonomy scopes do not overlap.
+    if search_string == false
+      result[:where] << '1=0'
+      return result
+    end
     return result if search_string.blank?
 
     begin
@@ -132,6 +137,7 @@ class Authorizer
       # Do not do any scoping if there's a filter which grants the permission universally
       base_conditions = filters.any? { |f| f.taxonomy_search.nil? && f.search.nil? } ? [] : filters.map(&:search_condition)
       tax_conditions = filters.first.taxonomy_search_condition_for_user(@user)
+      return false unless tax_conditions
 
       QueryBuilder.join(
         'AND',
@@ -146,7 +152,10 @@ class Authorizer
       # This means we cannot take any shortcuts and need to build a query where
       # the checks for user's taxonomies are evaluated for each filter
       # individually
-      conditions = filters.map { |f| f.search_condition_for_user(@user) }
+      conditions = filters.map { |filter| filter.search_condition_for_user(@user) }
+      conditions.reject! { |condition| condition == false }
+      return false if conditions.empty?
+
       QueryBuilder.join('OR', conditions)
     end
   end

--- a/test/controllers/api/v2/users_controller_test.rb
+++ b/test/controllers/api/v2/users_controller_test.rb
@@ -190,6 +190,19 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     end
   end
 
+  [:organizations, :locations].each do |taxonomy|
+    test "user with viewer rights and no #{taxonomy} should succeed in viewing users" do
+      user_one_as_anonymous_viewer
+      users(:one).public_send("#{taxonomy}=", [])
+
+      as_user :one do
+        get :index
+        assert_response :success
+        assert_empty ActiveSupport::JSON.decode(@response.body)['results']
+      end
+    end
+  end
+
   test 'admin user can be created' do
     user = users(:one)
     user.update_attribute :admin, true

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -191,8 +191,7 @@ class FilterTest < ActiveSupport::TestCase
 
     test 'works with conflicting existing taxonomy_search' do
       f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :taxonomy_search => "organization_id = 7", :resource_type => 'Domain')
-      expected = "((name ~ test*) AND (set? organization_id AND null? organization_id) AND (location_id ^ (#{@loc1.id},#{@loc2.id})))"
-      assert_equal expected, f.search_condition_for_user(@user)
+      assert_equal false, f.search_condition_for_user(@user)
     end
 
     test 'also covers nested organizations' do
@@ -216,8 +215,7 @@ class FilterTest < ActiveSupport::TestCase
       user_no_orgs.organizations = []
       user_no_orgs.locations = [@loc1]
       f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
-      expected = "((name ~ test*) AND (set? organization_id AND null? organization_id) AND (location_id ^ (#{@loc1.id})))"
-      assert_equal expected, f.search_condition_for_user(user_no_orgs)
+      assert_equal false, f.search_condition_for_user(user_no_orgs)
     end
 
     test 'handles user with no locations' do
@@ -225,8 +223,7 @@ class FilterTest < ActiveSupport::TestCase
       user_no_locs.organizations = [@org1]
       user_no_locs.locations = []
       f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
-      expected = "((name ~ test*) AND (organization_id ^ (#{@org1.id})) AND (set? location_id AND null? location_id))"
-      assert_equal expected, f.search_condition_for_user(user_no_locs)
+      assert_equal false, f.search_condition_for_user(user_no_locs)
     end
   end
 end


### PR DESCRIPTION
## Summary

Non-admin users with only an organization or only a location assigned could receive a 500 response when listing taxable resources.

An empty taxonomy intersection was represented as a contradictory Scoped Search expression using `set?` and `null?`. Unlike regular has-many conditions, Scoped Search does not wrap these operators in a subquery, leaving a direct reference to the `taxonomies` table after the eager-loads were removed in #39209.

Represent empty taxonomy intersections as no access and let the authorizer add an explicit false SQL condition. Filters without an overlapping taxonomy are skipped individually in the non-granular path.

This preserves the duplicate-result fix from #39209 without restoring the removed taxonomy eager-loads.

## Testing

- Ruby syntax checks pass for all changed files
- Foreman RuboCop passes for all changed files
- Regression tests cover users without organizations and users without locations

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
