### PR TITLE
Fixes #39371 - Handle bond and VLAN interface names

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -2,7 +2,7 @@ class FactParser
   delegate :logger, :to => :Rails
   VIRTUAL = /\A([a-z0-9]+)[_|.|:]([a-z0-9]+)\Z/
   BRIDGES = /\A(vir|lxc)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
-  BONDS = /\A(bond[\d-].*)\Z|\A(lagg\d)\Z/
+  BONDS = /\A(bond\d+|bond-[a-z0-9-]+|lagg\d+)\Z/
   ALIASES = /(\A[a-z0-9.]+):([a-z0-9]+)\Z/
   VLANS = /\A([a-zA-Z0-9]+)\.([0-9]+)\Z/
   VIRTUAL_NAMES = /#{ALIASES}|#{VLANS}|#{VIRTUAL}|#{BRIDGES}|#{BONDS}/

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -404,6 +404,15 @@ class HostTest < ActiveSupport::TestCase
     refute host.primary_interface.managed?
   end
 
+  test "should identify a VLAN on a bond as a managed primary interface" do
+    host = FactoryBot.build(:host)
+    parser = mock('parser')
+    parser.expects(:parse_interfaces?).returns(true)
+    parser.expects(:suggested_primary_interface).with(host).returns(['bond0.601', {}])
+
+    assert_equal 'Nic::Managed', host.primary_interface_type(parser)
+  end
+
   test "should ignore link-local ipv6 addresses when importing from facts" do
     host = FactoryBot.create(:host, :mac => '00:00:11:22:11:22')
 

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -13,8 +13,13 @@ class FactParserTest < ActiveSupport::TestCase
     assert_match FactParser::BONDS, 'bond-foo'
     assert_match FactParser::BONDS, 'bond-foo-bar'
     assert_match FactParser::BONDS, 'lagg0'
+    assert_match FactParser::BONDS, 'lagg10'
     refute_match FactParser::BONDS, 'bond'
     refute_match FactParser::BONDS, 'bonding'
+    refute_match FactParser::BONDS, 'bond0.0'
+    refute_match FactParser::BONDS, 'bond0:0'
+    refute_match FactParser::BONDS, 'bond0.0:0'
+    refute_match FactParser::BONDS, 'bond0_0'
   end
 
   test "bridge regexp matches bridges" do


### PR DESCRIPTION
## Summary

Fixes [#39371](https://projects.theforeman.org/issues/39371).

[PR #10744](https://github.com/theforeman/foreman/pull/10744) expanded the bond matcher to support hyphenated bond names, but `bond[\d-].*` also classifies conventional VLAN and alias names such as `bond0.601` and `bond0:0` as bonds. The same change unintentionally narrowed `lagg\d+` to a single digit.

As described in the [community report](https://community.theforeman.org/t/foreman-3-17-2-messed-up-interface-facts/46101/10):

> "`bond0.601` is a standard name for a tagged network interface on a bond interface."

Restrict bond detection to numeric `bond` names and `bond-` names containing letters, digits, or hyphens. This preserves `bond10` and `bond-foo-bar`, rejects VLAN and alias suffixes, and restores multi-digit `lagg` names.

## Testing

- Restore regression coverage for VLAN and alias names on top of bonds
- Cover `lagg10` alongside existing valid bond names
- Verify that `bond0.601` produces a `Nic::Managed` primary interface instead of `Nic::Bond`
- Ruby syntax and standalone matcher checks pass locally

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
