### PR TITLE
Fixes #39645 - Replace Fog::SSH/SCP with system SSH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,6 @@ gem 'gettext_i18n_rails', '~> 1.8'
 gem 'rails-i18n', '~> 7.0'
 gem 'logging', '>= 1.8.0', '< 3.0.0'
 gem 'fog-core', '~> 2.1'
-gem 'net-scp'
-gem 'net-ssh'
 gem 'net-ldap', '>= 0.16.0'
 gem 'net-ping', :require => false
 gem 'activerecord-session_store', '>= 2.0.0', '< 3'

--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -43,15 +43,19 @@ module Orchestration::SshProvision
   def setSSHWaitForResponse
     logger.info "Starting SSH provisioning script - waiting for #{provision_host} to respond"
     if compute_resource.respond_to?(:key_pair) && compute_resource.key_pair.try(:secret)
-      credentials = { :key_data => [compute_resource.key_pair.secret] }
+      credentials = { :key_data => compute_resource.key_pair.secret }
+      logger.info "Using SSH key pair authentication"
     elsif vm.respond_to?(:password) && vm.password.present?
-      credentials = { :password => vm.password, :auth_methods => ["password", "keyboard-interactive"] }
+      credentials = { :password => vm.password }
+      logger.info "Using password authentication from VM details"
     elsif image.respond_to?(:password) && image.password.present?
-      credentials = { :password => image.password, :auth_methods => ["password", "keyboard-interactive"] }
+      credentials = { :password => image.password }
+      logger.info "Using password authentication from image details"
     else
       raise ::Foreman::Exception.new(N_('Unable to find proper authentication method'))
     end
     self.client = Foreman::Provision::Ssh.new provision_host, image.try(:username), { :template => template_file.path, :uuid => uuid }.merge(credentials)
+    client.ping
   rescue => e
     failure _("Failed to login via SSH to %{name}: %{e}") % { :name => name, :e => e }, e
   end
@@ -60,7 +64,7 @@ module Orchestration::SshProvision
   end
 
   def setSSHProvision
-    logger.info "SSH connection established to #{provision_host} - executing template"
+    logger.info "SSH connection to #{provision_host} okay: executing template"
     if client.deploy!
       # since we are in a after_commit callback, we need to fetch our host again, and clean up puppet ca on our own
       Host.find(id).built

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -1,113 +1,121 @@
-require 'timeout'
+require 'open3'
 
-class Foreman::Provision::Ssh
-  attr_reader :template, :uuid, :results, :address, :username, :options
+module Foreman
+  module Provision
+    # Simple SSH client implemented via OpenSSH ssh and sshpass commands.
+    class Ssh
+      def initialize(address, username = "root", options = {})
+        @username = username
+        @address  = address
+        @template = options.delete(:template) || (raise ::Foreman::Exception.new(N_('must provide a template')))
+        @uuid     = options.delete(:uuid) || "#{@address}-#{@username}"
+        @options  = options
 
-  def initialize(address, username = "root", options = { })
-    @username = username
-    @address  = address
-    @template = options.delete(:template) || raise("must provide a template")
-    @uuid     = options.delete(:uuid)     || "#{address}-#{username}"
-    @options  = defaults.merge(options)
-
-    initiate_connection!
-  end
-
-  def deploy!
-    logger.debug "about to upload #{template} to remote system at #{remote_script}"
-    scp.upload(template, remote_script)
-    logger.debug "about to execute #{command}"
-    @results = ssh.run(command)
-    log_stdout
-    log_stderr
-    success?
-  end
-
-  private
-
-  def success?
-    return true if results.empty?
-    results.map(&:status).compact == [0]
-  end
-
-  def log_stdout
-    results.each do |r|
-      r.stdout.split("\n").each { |l| logger.debug l }
-    end
-  end
-
-  def log_stderr
-    results.each do |r|
-      r.stderr.split("\n").each { |l| logger.warn l }
-    end
-  end
-
-  def remote_script
-    "bootstrap-#{uuid}"
-  end
-
-  def command_prefix
-    (username == "root") ? "" : "sudo "
-  end
-
-  def command
-    # Use the users home to store the provision script since we can't reliably
-    # tell if other locations are writeable or executable by the user.
-    main_execution = "(chmod 0701 ./#{remote_script} && #{command_prefix} ./#{remote_script} ; echo $? >#{remote_script}.status) 2>&1"
-    "#{command_prefix} sh -c '#{main_execution} | tee #{remote_script}.log; exit $(cat #{remote_script}.status)'"
-  end
-
-  def defaults
-    {
-      :keys_only    => true,
-      :config       => false,
-      :auth_methods => %w(publickey),
-      :compression  => true,
-      :logger       => logger,
-    }
-  end
-
-  def logger
-    Rails.logger
-  end
-
-  def initiate_connection!
-    Timeout.timeout(Setting[:ssh_timeout].to_i) do
-      Timeout.timeout(8) do
-        ssh.run('pwd')
+        check_auth_options
       end
-    rescue Errno::ECONNREFUSED
-      logger.debug "Connection refused for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Errno::EHOSTUNREACH
-      logger.debug "Host unreachable for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Net::SSH::Disconnect
-      logger.debug "Host dropping connections for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Net::SSH::ConnectionTimeout
-      logger.debug "Host timed out for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Net::SSH::AuthenticationFailed
-      logger.debug "Auth failed for #{username} at #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Timeout::Error
-      retry
-    rescue => e
-      Foreman::Logging.exception("SSH error", e)
+
+      def deploy!
+        logger.info "Executing provisioning script on #{@address}"
+
+        _stdout, _stderr, status = run_ssh(
+          "#{command_prefix}sh",
+          stdin_data: File.binread(@template)
+        )
+
+        status.success?
+      end
+
+      # Wait for maximum of ssh_timeout setting for a client to complete full connection.
+      def ping
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + Setting[:ssh_timeout].to_i
+
+        logger.info "Making a ping SSH connection to #{@address}"
+
+        loop do
+          _stdout, _stderr, status = run_ssh("true")
+
+          if status.success?
+            return self
+          end
+
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            raise ::Foreman::Exception.new(
+              N_("Failed to connect to %{address} after %{timeout} seconds"),
+              {:address => @address, :timeout => Setting[:ssh_timeout]}
+            )
+          end
+
+          logger.debug "SSH connection to #{@address} failed, retrying..."
+          sleep 2
+        end
+      end
+
+      private
+
+      def run_ssh(remote_command, stdin_data: nil)
+        with_tmp_key do |key_file|
+          cmd = build_command(remote_command, key_file)
+          opts = {}
+          opts[:stdin_data] = stdin_data if stdin_data
+          stdout, stderr, status = Open3.capture3(*cmd, **opts)
+          logger.debug(stdout) if stdout.present?
+          stderr.each_line { |l| logger.warn(l.chomp) } if stderr.present?
+          [stdout, stderr, status]
+        end
+      end
+
+      def build_command(remote_command, key_file)
+        cmd = []
+        if @options[:password].present?
+          cmd.push({"SSHPASS" => @options[:password]}, "sshpass", "-e")
+        end
+        cmd.push("ssh", *ssh_options(key_file), "#{@username}@#{@address}", remote_command)
+        cmd
+      end
+
+      def ssh_options(key_file)
+        opts = %w[
+          -oStrictHostKeyChecking=no
+          -oUserKnownHostsFile=/dev/null
+          -oConnectTimeout=4
+          -oCompression=yes
+          -oBatchMode=yes
+        ]
+
+        opts.push("-oIdentityFile=#{key_file.path}") if key_file
+
+        methods = []
+        methods << "publickey" if @options[:key_data].present?
+        methods << "password" if @options[:password].present?
+        opts.push("-oPreferredAuthentications=#{methods.join(',')}")
+
+        opts
+      end
+
+      def command_prefix
+        @username == "root" ? "" : "sudo "
+      end
+
+      def with_tmp_key
+        return yield(nil) if @options[:key_data].blank?
+
+        Tempfile.create("foreman-ssh-#{@uuid}") do |f|
+          f.write(@options[:key_data])
+          yield f
+        end
+      end
+
+      def check_auth_options
+        return if @options[:key_data].present? || @options[:password].present?
+
+        raise Foreman::Exception.new(
+          N_("Missing SSH credentials: provide key_data or password")
+        )
+      end
+
+      def logger
+        Rails.logger
+      end
     end
-  end
-
-  def ssh
-    Fog::SSH.new(address, username, options.merge(:timeout => 4))
-  end
-
-  def scp
-    Fog::SCP.new(address, username, options)
   end
 end

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -4,6 +4,8 @@ module Foreman
   module Provision
     # Simple SSH client implemented via OpenSSH ssh and sshpass commands.
     class Ssh
+      SSH_FINISH_KEY = '/var/lib/foreman/ssh_finish_key'
+
       def initialize(address, username = "root", options = {})
         @username = username
         @address  = address
@@ -82,14 +84,27 @@ module Foreman
           -oBatchMode=yes
         ]
 
+        finish_key = ssh_finish_key?
         opts.push("-oIdentityFile=#{key_file.path}") if key_file
+        opts.push("-oIdentityFile=#{SSH_FINISH_KEY}") if finish_key
 
         methods = []
-        methods << "publickey" if @options[:key_data].present?
+        methods << "publickey" if @options[:key_data].present? || finish_key
         methods << "password" if @options[:password].present?
         opts.push("-oPreferredAuthentications=#{methods.join(',')}")
 
         opts
+      end
+
+      def ssh_finish_key?
+        return false unless File.file?(SSH_FINISH_KEY)
+
+        return true if (File.stat(SSH_FINISH_KEY).mode & 0o777) == 0o600
+
+        logger.warn "Ignoring #{SSH_FINISH_KEY} with incorrect permissions"
+        false
+      rescue Errno::ENOENT, Errno::EACCES
+        false
       end
 
       def command_prefix

--- a/test/unit/foreman/provision/ssh_test.rb
+++ b/test/unit/foreman/provision/ssh_test.rb
@@ -1,0 +1,180 @@
+require 'test_helper'
+
+class SshProvisionServiceTest < ActiveSupport::TestCase
+  def setup
+    @template = Tempfile.new('provision-test')
+    @template.write("#!/bin/sh\necho hello\n")
+    @template.close
+  end
+
+  def teardown
+    @template.unlink
+  end
+
+  def success_status
+    stub(success?: true)
+  end
+
+  def failure_status
+    stub(success?: false)
+  end
+
+  def stub_capture3(stdout: "", stderr: "", status: success_status)
+    Open3.stubs(:capture3).returns([stdout, stderr, status])
+  end
+
+  def new_ssh(address: "192.168.1.1", username: "root", options: {})
+    defaults = { template: @template.path, uuid: "test-uuid", key_data: "fake-private-key" }
+    Foreman::Provision::Ssh.new(address, username, defaults.merge(options))
+  end
+
+  test "raises when no credentials provided" do
+    assert_raises(Foreman::Exception) do
+      Foreman::Provision::Ssh.new("192.168.1.1", "root", template: @template.path, uuid: "x")
+    end
+  end
+
+  test "raises when template is missing" do
+    assert_raises(Foreman::Exception) do
+      Foreman::Provision::Ssh.new("192.168.1.1", "root", key_data: "key")
+    end
+  end
+
+  describe '#deploy!' do
+    test "returns true on success" do
+      stub_capture3
+      ssh = new_ssh
+      assert ssh.deploy!
+    end
+
+    test "returns false on failure" do
+      stub_capture3(status: failure_status)
+      ssh = new_ssh
+      refute ssh.deploy!
+    end
+
+    test "passes template content via stdin to sh" do
+      ssh = new_ssh
+      Open3.expects(:capture3).with do |*args|
+        opts = args.last.is_a?(Hash) ? args.last : {}
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        cmd_args.include?("sh") && opts[:stdin_data] == File.binread(@template.path)
+      end.returns(["", "", success_status])
+      ssh.deploy!
+    end
+
+    test "uses sudo for non-root user" do
+      ssh = new_ssh(username: "admin")
+      Open3.expects(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        cmd_args.include?("sudo sh")
+      end.returns(["", "", success_status])
+      ssh.deploy!
+    end
+  end
+
+  describe '#ping' do
+    test "returns self on successful connection" do
+      stub_capture3
+      ssh = new_ssh
+      assert_equal ssh, ssh.ping
+    end
+
+    test "raises after timeout" do
+      Setting[:ssh_timeout] = 1
+      stub_capture3(status: failure_status)
+      ssh = new_ssh
+      ssh.stubs(:sleep)
+      error = assert_raises(Foreman::Exception) { ssh.ping }
+      assert_match(/Failed to connect/, error.message)
+    end
+  end
+
+  describe 'key file management' do
+    test "key file is removed after run_ssh" do
+      ssh = new_ssh
+      key_paths = []
+      Open3.stubs(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        identity_arg = cmd_args.find { |a| a.to_s.start_with?("-oIdentityFile=") }
+        if identity_arg
+          path = identity_arg.sub("-oIdentityFile=", "")
+          key_paths << path
+          assert File.exist?(path), "Key file should exist during SSH execution"
+        end
+        true
+      end.returns(["", "", success_status])
+
+      ssh.ping
+      assert key_paths.any?, "Expected an identity file argument"
+      key_paths.each do |path|
+        refute File.exist?(path), "Key file should be removed after run_ssh"
+      end
+    end
+
+    test "key file has 0600 permissions" do
+      ssh = new_ssh
+      Open3.stubs(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        identity_arg = cmd_args.find { |a| a.to_s.start_with?("-oIdentityFile=") }
+        if identity_arg
+          path = identity_arg.sub("-oIdentityFile=", "")
+          mode = File.stat(path).mode & 0o777
+          assert_equal 0o600, mode, "Key file permissions should be 0600"
+        end
+        true
+      end.returns(["", "", success_status])
+      ssh.ping
+    end
+
+    test "no identity file when using password auth" do
+      ssh = new_ssh(options: { key_data: nil, password: "secret" })
+      Open3.expects(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        refute cmd_args.any? { |a| a.to_s.include?("IdentityFile") }, "Should not have IdentityFile"
+        true
+      end.returns(["", "", success_status])
+      ssh.ping
+    end
+  end
+
+  describe 'command building' do
+    test "uses sshpass for password auth" do
+      ssh = new_ssh(options: { key_data: nil, password: "secret" })
+      Open3.expects(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        assert_equal({"SSHPASS" => "secret"}, cmd_args[0])
+        assert_equal "sshpass", cmd_args[1]
+        assert_equal "-e", cmd_args[2]
+        true
+      end.returns(["", "", success_status])
+      ssh.ping
+    end
+
+    test "includes correct ssh options" do
+      ssh = new_ssh
+      Open3.expects(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        assert_includes cmd_args, "-oStrictHostKeyChecking=no"
+        assert_includes cmd_args, "-oUserKnownHostsFile=/dev/null"
+        assert_includes cmd_args, "-oConnectTimeout=4"
+        assert_includes cmd_args, "-oCompression=yes"
+        assert_includes cmd_args, "-oBatchMode=yes"
+        assert_includes cmd_args, "-oPreferredAuthentications=publickey"
+        assert_includes cmd_args, "root@192.168.1.1"
+        true
+      end.returns(["", "", success_status])
+      ssh.ping
+    end
+
+    test "sets both auth methods when key and password present" do
+      ssh = new_ssh(options: { key_data: "key", password: "pass" })
+      Open3.expects(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        assert_includes cmd_args, "-oPreferredAuthentications=publickey,password"
+        true
+      end.returns(["", "", success_status])
+      ssh.ping
+    end
+  end
+end

--- a/test/unit/foreman/provision/ssh_test.rb
+++ b/test/unit/foreman/provision/ssh_test.rb
@@ -136,6 +136,34 @@ class SshProvisionServiceTest < ActiveSupport::TestCase
       end.returns(["", "", success_status])
       ssh.ping
     end
+
+    test "includes the SSH finish key when it has 0600 permissions" do
+      File.stubs(:file?).with(Foreman::Provision::Ssh::SSH_FINISH_KEY).returns(true)
+      File.stubs(:stat).with(Foreman::Provision::Ssh::SSH_FINISH_KEY).returns(stub(mode: 0o100600))
+      ssh = new_ssh
+
+      Open3.expects(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        assert_includes cmd_args, "-oIdentityFile=#{Foreman::Provision::Ssh::SSH_FINISH_KEY}"
+        assert_includes cmd_args, "-oPreferredAuthentications=publickey"
+        true
+      end.returns(["", "", success_status])
+      ssh.ping
+    end
+
+    test "does not include the SSH finish key without 0600 permissions" do
+      File.stubs(:file?).with(Foreman::Provision::Ssh::SSH_FINISH_KEY).returns(true)
+      File.stubs(:stat).with(Foreman::Provision::Ssh::SSH_FINISH_KEY).returns(stub(mode: 0o100644))
+      Rails.logger.expects(:warn).with("Ignoring /var/lib/foreman/ssh_finish_key with incorrect permissions")
+      ssh = new_ssh
+
+      Open3.expects(:capture3).with do |*args|
+        cmd_args = args.last.is_a?(Hash) ? args[0..-2] : args
+        refute_includes cmd_args, "-oIdentityFile=#{Foreman::Provision::Ssh::SSH_FINISH_KEY}"
+        true
+      end.returns(["", "", success_status])
+      ssh.ping
+    end
   end
 
   describe 'command building' do


### PR DESCRIPTION
Rubygem `net-ssh` does not provide all features for PQC and overall, we would like to simplify crypto stack in Foreman. This patch refactors the SSH service class so it shells out to `ssh` and `sshpass` instead.

The previous workflow was also quite complex, the main goal of the SSH finish script is not super-resilient SSH scheduling, but to bootstrap other components like Remote Execution or Ansible and for this, there is no need to establish a long-lasting connection via sockets.

Furthermore, the old solution copied the script using `scp` which is also unnecessary. Instead, there are simply two connections made using `ssh` command:

* The initial wait for the VM is done via `ping` method, previously this was named `estabilish_connection!` but this would be confusing. I made the method explicit so constructor does not perform this - this was confusing behavior.
* The final call is then done via `deploy!` method, instead of `scp` the script is simply passed via STDIN - no need of temporary files.

Other major changes to further simplify the code:

* For sshkey authentication, the temporary file with the private key is no longer created in the constructor relying on the `cleanup` method call. Instead, it is created just for the minimum possible time in the `run_ssh` method and cleaned immediately.
* Logging was moved to `run_ssh` method (DRY).
* Unit test was written by Claude, a bit heavy to my taste I will happily drop some cases.

I thought for a moment that we could even get rid of the `ping` and simply try to execute the template directly in a loop, but I discarded the idea. It is safer to be explicit.

I tested this via rails command in the proper SELinux policy with a small change (see the linked PR):

```
systemd-run --pipe --wait --service-type=oneshot \
  -p SELinuxContext=system_u:system_r:foreman_rails_t:s0 \
  -p User=foreman \
  -p WorkingDirectory=/usr/share/foreman \
  -p Environment=RAILS_ENV=production \
  -p PrivateTmp=no \
  /usr/share/foreman/bin/rails runner /tmp/test_ssh_provision.rb
```

This is a followup for previous work in https://github.com/theforeman/foreman/pull/10518 and https://github.com/theforeman/foreman/pull/10615 which was reverted.

**TODO**

* [x] Create PR to SELinux policy with the changes.
* [x] Add `ssh` and `sshpass` dependencies to `foreman` package.
* [ ] Drop `ssh-ssh/scp` packages from our repos. (After we drop the library from ReX)

Relevant PRs:

* https://github.com/theforeman/foreman-packaging/pull/14041
* https://github.com/theforeman/foreman-packaging/pull/14042