### PR TITLE
Fixes #39650 - Deduplicate taxonomy ids to prevent duplicate taxable_…

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -196,9 +196,20 @@ module Taxonomix
   def set_current_taxonomy
     if new_record? && errors.empty?
       # we need to use _ids methods so that DirtyAssociations is correctly saved
-      self.location_ids += [Location.current.id] if add_current_location?
-      self.organization_ids += [Organization.current.id] if add_current_organization?
+      self.location_ids |= [Location.current.id] if add_current_location?
+      self.organization_ids |= [Organization.current.id] if add_current_organization?
     end
+  end
+
+  # Defensive guard: never let a duplicate id reach the has_many :through
+  # ids_writer, or the second INSERT into taxable_taxonomies raises
+  # "Validation failed: Taxonomy has already been taken".
+  def organization_ids=(ids)
+    super(Array(ids).uniq)
+  end
+
+  def location_ids=(ids)
+    super(Array(ids).uniq)
   end
 
   def add_current_organization?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1428,4 +1428,37 @@ class UserTest < ActiveSupport::TestCase
       assert_equal user.id_and_type, Setting[:host_owner]
     end
   end
+
+  test "user can be saved when the current organization/location is already assigned" do
+    org = taxonomies(:organization1)
+    loc = taxonomies(:location1)
+
+    user = FactoryBot.create(:user, :organizations => [org], :locations => [loc])
+
+    Organization.current = org
+    Location.current     = loc
+
+    reloaded = User.find(user.id)
+
+    assert_nothing_raised do
+      reloaded.update!(
+        :password => "NewPassword123!",
+        :password_confirmation => "NewPassword123!"
+      )
+    end
+  ensure
+    Organization.current = nil
+    Location.current     = nil
+  end
+
+  test "organization_ids= and location_ids= dedupe input before writing" do
+    org  = taxonomies(:organization1)
+    user = FactoryBot.create(:user)
+
+    user.organization_ids = [org.id, org.id]
+    user.save!
+
+    assert_equal 1,
+      TaxableTaxonomy.where(:taxable_id => user.id, :taxable_type => 'User', :taxonomy_id => org.id).count
+  end
 end


### PR DESCRIPTION
**Description** :

Non-admin users assigned as `owner` on a Host could not change their own password. The update failed with "Validation failed: Taxonomy has already been taken", rolling back the otherwise unrelated password change along with it.

**Root cause**: 

`Taxonomix#set_current_taxonomy` appends the current session's Organization/Location id with `+=`, which does not deduplicate. Once a user is set as `owner` of a host in another taxonomy context, the id can already be present in `location_ids`/`organization_ids`, and `+=` appends it again. The duplicate reaches the `has_many :through` `ids_writer` for `organization_ids=`/`location_ids=`, which tries to insert the same `(taxable_id, taxable_type, taxonomy_id)` row into `taxable_taxonomies` twice within one transaction. The second insert fails a uniqueness validation on `TaxableTaxonomy`, and the whole save
- including the password change - is rolled back with it.

**Two changes fix this**:

- `set_current_taxonomy` now uses `|=` instead of `+=`, so an id already present is never re-added.
- `organization_ids=`/`location_ids=` dedupe their input before delegating to the generated `has_many :through` writer, so any other caller that produces a duplicate id (a plugin, a form posting repeated values, etc.) can't trigger the same failure through a different path.

I tested this on two live Red Hat Satellite instances (6.18.z and 6.19.z), and it worked as expected.

1. Create non-admin user `test`, permissions: register hosts / view hosts / edit hosts
2. Confirm `test` can change their own password (works)
3. As admin, set `test` as owner on a host
4. Log in as `test`, try to change password again -> before this patch: "Validation failed: Taxonomy has already been taken" -> after this patch: succeeds


**Related: Red Hat Jira** : 

https://projects.theforeman.org/issues/39650
https://redhat.atlassian.net/browse/SAT-44624



