### PR TITLE
Fixes #39653 - Remove Puppet 6 references

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -22,7 +22,6 @@ description: |
   This template accepts the following parameters:
   - force-puppet: boolean (default=false)
   - enable-puppetlabs-repo: boolean (default=false)
-  - enable-puppetlabs-puppet6-repo: boolean (default=false)
   - enable-official-puppet7-repo: boolean (default=false)
   - enable-official-puppet8-repo: boolean (default=false)
   - skip-puppet-setup: boolean (default=false)
@@ -42,7 +41,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 -%>

--- a/app/views/unattended/provisioning_templates/finish/agama_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/agama_default_finish.erb
@@ -9,7 +9,7 @@ oses:
 <%
   pm_set = @host.puppet_server.present?
   puppet_enabled = pm_set || host_param_true?('force-puppet')
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
 -%>

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -36,7 +36,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -14,7 +14,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-puppetlabs-puppet6-repo: boolean (default=undef)
   - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
@@ -31,7 +30,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -23,7 +23,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-puppetlabs-puppet6-repo: boolean (default=undef)
   - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
@@ -40,7 +39,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
 -%>
 #!/bin/bash

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -11,7 +11,7 @@ description: |
   os_major = @host.operatingsystem.major.to_i
   os_minor = @host.operatingsystem.minor.to_i
   # safemode renderer does not support unary negation
-  puppetlabs_repo_enabled = host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6')
+  puppetlabs_repo_enabled = host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7')
   voxpupuli_repo_enabled = [9, 8].any? { |version| host_param_true?("enable-openvox#{version}-repo") }
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
   salt_enabled = host_param('salt_master') ? true : false
@@ -310,15 +310,13 @@ rm /etc/resolv.conf
   <% end -%>
 <% end -%>
 <% if puppet_enabled && puppetlabs_repo_enabled -%>
-<% if host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') -%>
+<% if host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') -%>
 <%
   puppet_repo_url_base = 'http://yum.puppet.com'
   if host_param_true?('enable-official-puppet8-repo')
     puppet_repo_url = "#{puppet_repo_url_base}/puppet8/sles/#{os_major}/#{@host.architecture}/"
   elsif host_param_true?('enable-official-puppet7-repo')
     puppet_repo_url = "#{puppet_repo_url_base}/puppet7/sles/#{os_major}/#{@host.architecture}/"
-  elsif host_param_true?('enable-puppetlabs-puppet6-repo')
-    puppet_repo_url = "#{puppet_repo_url_base}/puppet6/sles/#{os_major}/#{@host.architecture}/"
   end
 %>
     <listentry>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -34,7 +34,6 @@ description: |
   - force-puppet: boolean (default=false)
   - enable-epel: boolean (default=false)
   - enable-puppetlabs-repo: boolean (default=false)
-  - enable-puppetlabs-puppet6-repo: boolean (default=false)
   - enable-official-puppet7-repo: boolean (default=false)
   - enable-official-puppet8-repo: boolean (default=false)
   - enable-openvox8: boolean (default=undef)
@@ -79,7 +78,7 @@ description: |
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   proxy_string = proxy_uri ? " --proxy=#{proxy_uri}" : ''
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -6,13 +6,13 @@ snippet: true
 description: |
   Generates a puppet.conf file which is required for the puppet agent bootstraping.
   The puppet server and CA is configured based on the host configuration. It supports
-  Puppet 6 and newer. Supports hostcert_renewal_interval for Puppet 8+.
+  Puppet 7 and newer. Supports hostcert_renewal_interval for Puppet 8+.
 -%>
 <%
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('enable-puppetlabs-repo') ||  host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6')
+  aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7')
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_family == 'Suse'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -17,7 +17,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6')
+aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7')
 aio_openvox_enabled = %w(enable-openvox9 enable-openvox9-repo enable-openvox8 enable-openvox8-repo).any? { |param| host_param_true?(param) }
 
 if aio_enabled && aio_openvox_enabled

--- a/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -18,7 +18,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
 voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
 
 if puppetlabs_repo_enabled && voxpupuli_repo_enabled
@@ -56,8 +56,6 @@ elsif host_param_true?('enable-official-puppet8-repo')
   repo_name = 'puppet8-release'
 elsif host_param_true?('enable-official-puppet7-repo')
   repo_name = 'puppet7-release'
-elsif host_param_true?('enable-puppetlabs-puppet6-repo')
-  repo_name = 'puppet6-release'
 end
 -%>
 <% if repo_name -%>

--- a/app/views/unattended/provisioning_templates/snippet/voxpupuli_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/voxpupuli_repo.erb
@@ -26,7 +26,7 @@ proxy_uri    = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{
 proxy_string = proxy_uri ? " -e https_proxy=#{proxy_uri}/" : ''
 proxy_string_bits = proxy_uri ? " -ProxyUsage Override -ProxyList #{proxy_uri}" : ''
 
-puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
 voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
 
 if puppetlabs_repo_enabled && voxpupuli_repo_enabled

--- a/app/views/unattended/provisioning_templates/user_data/agama_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/agama_default_user_data.erb
@@ -14,7 +14,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
 -%>

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -13,7 +13,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-puppetlabs-puppet6-repo: boolean (default=undef)
   - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
@@ -30,7 +29,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
 -%>

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -20,7 +20,6 @@ description: |
   - enable-official-puppet8-repo: boolean (default=false)
   - enable-openvox8: boolean (default=false)
   - enable-openvox9: boolean (default=false)
-  - enable-puppetlabs-puppet6-repo: boolean (default=false)
   - enable-puppetlabs-repo: boolean (default=false)
   - force-puppet: boolean (default=false)
   - package_upgrade: boolean (default=true)
@@ -39,7 +38,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -16,7 +16,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-puppetlabs-puppet6-repo: boolean (default=undef)
   - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
@@ -39,7 +38,7 @@ description: |
   # safemode renderer does not support unary negation
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -21,7 +21,6 @@ description: |
   - package_upgrade: boolean (default=false)
   - reboot: boolean (default=false)
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-puppetlabs-puppet6-repo: boolean (default=undef)
   - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
@@ -42,7 +41,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy


### PR DESCRIPTION
Puppet 6 reached EOL in 2023. Remove its version-specific host parameters, repository setup, package references, and documentation from provisioning templates.

This updates the documented minimum Puppet version to 7 while preserving the existing Puppet and OpenVox package selection. It does not automatically migrate hosts to another implementation.

## Verification

- compiled every changed ERB template
- checked the complete active provisioning-template tree for remaining Puppet 6 references
- verified the resulting Puppet 7 and Puppet 8 repository paths
- verified Puppet 8 is present in the supported FreeBSD 14.4 and 15.1 release ports branches
- full test suite runs in CI

## AI assistance

This pull request was prepared with assistance from Codex 5.6 Sol High.
