### PR TITLE
Fixes #39654 - Remove Puppet 7 references

### DIFF
--- a/app/services/foreman/renderer/scope/macros/host_template.rb
+++ b/app/services/foreman/renderer/scope/macros/host_template.rb
@@ -15,7 +15,7 @@ module Foreman
             list :path, 'List of strings representing path to a parameter to be returned'
             raises error: HostENCParamUndefined, desc: "when the parameter is not set in host's ENC output"
             returns one_of: [Hash, Object], desc: 'The value of a parameter or a key=value object with all information from ENC'
-            example "host_enc('parameters', 'enable-puppet7') #=> true"
+            example "host_enc('parameters', 'enable-puppet8') #=> true"
             example 'host_enc #=> {"parameters"=>{...}'
           end
           def host_enc(*path)

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -22,7 +22,6 @@ description: |
   This template accepts the following parameters:
   - force-puppet: boolean (default=false)
   - enable-puppetlabs-repo: boolean (default=false)
-  - enable-official-puppet7-repo: boolean (default=false)
   - enable-official-puppet8-repo: boolean (default=false)
   - skip-puppet-setup: boolean (default=false)
   - enable-openvox8: boolean (default=false)
@@ -41,7 +40,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 -%>

--- a/app/views/unattended/provisioning_templates/finish/agama_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/agama_default_finish.erb
@@ -9,7 +9,7 @@ oses:
 <%
   pm_set = @host.puppet_server.present?
   puppet_enabled = pm_set || host_param_true?('force-puppet')
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
 -%>

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -36,7 +36,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -14,7 +14,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
   - enable-openvox9: boolean (default=undef)
@@ -30,7 +29,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -23,7 +23,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
   - enable-openvox9: boolean (default=undef)
@@ -39,7 +38,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
 -%>
 #!/bin/bash

--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -9,7 +9,7 @@ description: |
 -%>
 <%
   # safemode renderer does not support unary negation
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || %w[official-puppet8 official-puppet7].any? { |repo| host_param_true?("enable-#{repo}-repo") }
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = [9, 8].any? { |version| host_param_true?("enable-openvox#{version}-repo") }
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
   salt_enabled = host_param('salt_master') ? true : false
@@ -295,9 +295,6 @@ rm /etc/resolv.conf
   if host_param_true?('enable-official-puppet8-repo')
     puppet_repo_url = "#{puppet_repo_url_base}/puppet8/sles/#{os_major}/#{@host.architecture}/"
     puppet_repo_alias = 'puppet8-release'
-  elsif host_param_true?('enable-official-puppet7-repo')
-    puppet_repo_url = "#{puppet_repo_url_base}/puppet7/sles/#{os_major}/#{@host.architecture}/"
-    puppet_repo_alias = 'puppet7-release'
   else
     puppet_repo_url = "#{puppet_repo_url_base}/puppet/sles/#{os_major}/#{@host.architecture}/"
     puppet_repo_alias = 'puppet-release'

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -11,7 +11,7 @@ description: |
   os_major = @host.operatingsystem.major.to_i
   os_minor = @host.operatingsystem.minor.to_i
   # safemode renderer does not support unary negation
-  puppetlabs_repo_enabled = host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7')
+  puppetlabs_repo_enabled = host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8')
   voxpupuli_repo_enabled = [9, 8].any? { |version| host_param_true?("enable-openvox#{version}-repo") }
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
   salt_enabled = host_param('salt_master') ? true : false
@@ -310,14 +310,10 @@ rm /etc/resolv.conf
   <% end -%>
 <% end -%>
 <% if puppet_enabled && puppetlabs_repo_enabled -%>
-<% if host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') -%>
+<% if host_param_true?('enable-official-puppet8-repo') -%>
 <%
   puppet_repo_url_base = 'http://yum.puppet.com'
-  if host_param_true?('enable-official-puppet8-repo')
-    puppet_repo_url = "#{puppet_repo_url_base}/puppet8/sles/#{os_major}/#{@host.architecture}/"
-  elsif host_param_true?('enable-official-puppet7-repo')
-    puppet_repo_url = "#{puppet_repo_url_base}/puppet7/sles/#{os_major}/#{@host.architecture}/"
-  end
+  puppet_repo_url = "#{puppet_repo_url_base}/puppet8/sles/#{os_major}/#{@host.architecture}/"
 %>
     <listentry>
         <media_url><![CDATA[<%= puppet_repo_url %>]]></media_url>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -34,7 +34,6 @@ description: |
   - force-puppet: boolean (default=false)
   - enable-epel: boolean (default=false)
   - enable-puppetlabs-repo: boolean (default=false)
-  - enable-official-puppet7-repo: boolean (default=false)
   - enable-official-puppet8-repo: boolean (default=false)
   - enable-openvox8: boolean (default=undef)
   - enable-openvox9: boolean (default=undef)
@@ -78,7 +77,7 @@ description: |
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   proxy_string = proxy_uri ? " --proxy=#{proxy_uri}" : ''
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -6,13 +6,13 @@ snippet: true
 description: |
   Generates a puppet.conf file which is required for the puppet agent bootstraping.
   The puppet server and CA is configured based on the host configuration. It supports
-  Puppet 7 and newer. Supports hostcert_renewal_interval for Puppet 8+.
+  Puppet 8 and newer.
 -%>
 <%
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7')
+  aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8')
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_family == 'Suse'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -17,7 +17,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7')
+aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8')
 aio_openvox_enabled = %w(enable-openvox9 enable-openvox9-repo enable-openvox8 enable-openvox8-repo).any? { |param| host_param_true?(param) }
 
 if aio_enabled && aio_openvox_enabled

--- a/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -18,7 +18,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
 voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
 
 if puppetlabs_repo_enabled && voxpupuli_repo_enabled
@@ -54,8 +54,6 @@ if host_param_true?('enable-puppetlabs-repo')
   repo_name = 'puppet-release'
 elsif host_param_true?('enable-official-puppet8-repo')
   repo_name = 'puppet8-release'
-elsif host_param_true?('enable-official-puppet7-repo')
-  repo_name = 'puppet7-release'
 end
 -%>
 <% if repo_name -%>

--- a/app/views/unattended/provisioning_templates/snippet/voxpupuli_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/voxpupuli_repo.erb
@@ -26,7 +26,7 @@ proxy_uri    = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{
 proxy_string = proxy_uri ? " -e https_proxy=#{proxy_uri}/" : ''
 proxy_string_bits = proxy_uri ? " -ProxyUsage Override -ProxyList #{proxy_uri}" : ''
 
-puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
 voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
 
 if puppetlabs_repo_enabled && voxpupuli_repo_enabled

--- a/app/views/unattended/provisioning_templates/user_data/agama_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/agama_default_user_data.erb
@@ -14,7 +14,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
 -%>

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -13,7 +13,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
   - enable-openvox9: boolean (default=undef)
@@ -29,7 +28,7 @@ description: |
 <%
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
 -%>

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -16,7 +16,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-epel: boolean (default=undef)
-  - enable-official-puppet7-repo: boolean (default=false)
   - enable-official-puppet8-repo: boolean (default=false)
   - enable-openvox8: boolean (default=false)
   - enable-openvox9: boolean (default=false)
@@ -38,7 +37,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -16,7 +16,6 @@ description: |
 
   This template accepts the following parameters:
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
   - enable-openvox9: boolean (default=undef)
@@ -38,7 +37,7 @@ description: |
   # safemode renderer does not support unary negation
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -21,7 +21,6 @@ description: |
   - package_upgrade: boolean (default=false)
   - reboot: boolean (default=false)
   - enable-puppetlabs-repo: boolean (default=undef)
-  - enable-official-puppet7-repo: boolean (default=undef)
   - enable-official-puppet8-repo: boolean (default=undef)
   - enable-openvox8: boolean (default=undef)
   - enable-openvox9: boolean (default=undef)
@@ -41,7 +40,7 @@ description: |
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo')
+  puppetlabs_repo_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo')
   voxpupuli_repo_enabled = host_param_true?('enable-openvox9-repo') || host_param_true?('enable-openvox8-repo')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy


### PR DESCRIPTION
Puppet 7 reached EOL in 2025. Remove its version-specific host parameters, repository setup, and documentation from provisioning templates.

Puppet 8 remains the supported Puppet version while the existing OpenVox 8/9 repository and package paths are preserved. This does not automatically migrate hosts to another implementation.

The `host_enc` example now uses Puppet 8, and AutoYaST version selection is simplified while preserving the Puppet 8 SLES repository path fixed in #39624.

## Verification

- rebased onto current `develop` after #10928 and #11180 were merged
- compiled all 140 provisioning ERB templates
- checked the complete active provisioning-template tree for remaining Puppet 5, 6, or 7 references
- preserved the current Puppet 8 and OpenVox 8/9 selection and repository paths
- full test suite runs in CI

## AI assistance

This pull request was prepared with assistance from Codex 5.6 Sol High.
