### PR TITLE
Fixes #39656 - Use selected Puppet repository on Windows

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -34,6 +34,13 @@ elsif os_family == 'Debian'
 elsif os_family == 'Windows'
   repo_host = 'downloads.puppet.com'
   repo_os = 'windows'
+  puppet_architecture = @host.architecture.to_s
+  case puppet_architecture
+  when 'x86_64', 'x86-64', 'amd64'
+    puppet_architecture = 'x64'
+  when 'i386', 'i486', 'i586', 'i686'
+    puppet_architecture = 'x86'
+  end
 end
 
 if host_param_true?('enable-puppetlabs-repo')
@@ -57,8 +64,8 @@ apt-get -y install ca-certificates
 wget -O /tmp/<%= repo_name %>-<%= repo_os %>.deb<%= proxy_string %> https://<%= repo_host %>/<%= repo_name %>-<%= repo_os %>.deb
 dpkg -i /tmp/<%= repo_name %>-<%= repo_os %>.deb
 <% elsif os_family == 'Windows' -%>
-$puppet_agent_source = 'https://<%= repo_host %>/<%= repo_os %>/puppet-agent-<%= @host.architecture %>-latest.msi'
-$puppet_agent_msi = "${env:TEMP}\puppet-agent-<%= @host.architecture %>.msi"
+$puppet_agent_source = 'https://<%= repo_host %>/<%= repo_os %>/<%= repo_name.split('-').first %>/puppet-agent-<%= puppet_architecture %>-latest.msi'
+$puppet_agent_msi = "${env:TEMP}\puppet-agent-<%= puppet_architecture %>.msi"
 Write-Host "Downloading puppet-agent from ${$puppet_agent_source} to ${puppet_agent_msi}"
 Start-BitsTransfer -Source "${puppet_agent_source}" -Destination "${puppet_agent_msi}"<%= proxy_string_bits %>
 <% end -%>

--- a/test/unit/foreman/templates/snippets/puppetlabs_repo_test.rb
+++ b/test/unit/foreman/templates/snippets/puppetlabs_repo_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class PuppetlabsRepoTest < ActiveSupport::TestCase
+  def renderer
+    @renderer ||= Foreman::Renderer::SafeModeRenderer
+  end
+
+  def render_template(parameters)
+    @snippet ||= File.read(Rails.root.join('app', 'views', 'unattended', 'provisioning_templates', 'snippet', 'puppetlabs_repo.erb'))
+    @host.stubs(:params).returns(parameters)
+    @host.stubs(:host_param).returns(nil)
+
+    source = OpenStruct.new(
+      name: 'Test',
+      content: @snippet
+    )
+    scope = Class.new(Foreman::Renderer::Scope::Provisioning).send(
+      :new,
+      host: @host,
+      source: source
+    )
+
+    renderer.render(source, scope)
+  end
+
+  setup do
+    @host = FactoryBot.build(
+      :host_for_snapshots_ipv4_dhcp_windows10,
+      architecture: FactoryBot.build(:architecture, :x64)
+    )
+  end
+
+  test 'uses the generic Puppet collection on Windows' do
+    rendered = render_template('enable-puppetlabs-repo' => true)
+
+    assert_includes rendered, 'https://downloads.puppet.com/windows/puppet/puppet-agent-x64-latest.msi'
+  end
+
+  test 'uses the Puppet 8 collection on Windows' do
+    rendered = render_template('enable-official-puppet8-repo' => true)
+
+    assert_includes rendered, 'https://downloads.puppet.com/windows/puppet8/puppet-agent-x64-latest.msi'
+  end
+
+  test 'normalizes 64-bit architecture names for Puppet downloads on Windows' do
+    %w[x86_64 x86-64 amd64].each do |architecture|
+      @host.architecture = FactoryBot.build(:architecture, name: architecture)
+
+      rendered = render_template('enable-official-puppet8-repo' => true)
+
+      assert_includes rendered, 'https://downloads.puppet.com/windows/puppet8/puppet-agent-x64-latest.msi'
+    end
+  end
+
+  test 'normalizes 32-bit architecture names for Puppet downloads on Windows' do
+    %w[x86 i386 i486 i586 i686].each do |architecture|
+      @host.architecture = FactoryBot.build(:architecture, name: architecture)
+
+      rendered = render_template('enable-official-puppet8-repo' => true)
+
+      assert_includes rendered, 'https://downloads.puppet.com/windows/puppet8/puppet-agent-x86-latest.msi'
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#39656](https://projects.theforeman.org/issues/39656).

The Windows branch of `puppetlabs_repo` ignored the selected Puppet repository and always downloaded the root-level `puppet-agent-*-latest.msi`, which has not been updated since 2018.

Include the collection encoded in `repo_name` in the Windows download path. The generic `puppet-release` repository now uses `/windows/puppet/`, while `puppet8-release` uses `/windows/puppet8/`. Linux repository URLs are unchanged.

Add safe-mode rendering tests for both supported selections.

## Testing

- Ruby test syntax passes
- ERB compilation passes
- Standalone rendering produces the expected generic and Puppet 8 Windows URLs
- Both generated MSI URLs return HTTP 200

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
