### PR TITLE
Refs #39662 - Skip libvirt dependent tests if libvirt is unavailable

### DIFF
--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -1,3 +1,18 @@
+# Libvirt support is optional, the fog-libvirt and ruby-libvirt gems are only
+# loaded when the system libvirt libraries are present. CI is expected to have
+# libvirt installed, so the libvirt tests must run there even if the gems are
+# missing - failing loudly is better than silently losing test coverage.
+def libvirt_available?
+  # Both GitHub Actions and GitLab CI set CI=true, as does Jenkins.
+  return true if ENV['CI'].present?
+
+  Foreman::Model::Libvirt.available?
+end
+
+def skip_without_libvirt
+  skip 'libvirt is not available' unless libvirt_available?
+end
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
   # Note: You'll currently still have to declare fixtures explicitly in integration tests

--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -34,6 +34,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update compute resource" do
+    skip_without_libvirt
     put :update, params: { :id => compute_resources(:mycompute).to_param, :compute_resource => { :description => "new_description" } }
     assert_equal "new_description",
       ComputeResource.unscoped.find_by_name('mycompute').description
@@ -65,6 +66,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update compute resource for owner" do
+    skip_without_libvirt
     setup_user 'edit', 'compute_resources', "id = #{compute_resources(:mycompute).id}"
     put :update, params: { :id => compute_resources(:mycompute).to_param, :compute_resource => { :description => "new_description" } }
     assert_equal "new_description",
@@ -112,6 +114,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should get available virtual machines" do
+    skip_without_libvirt
     vm = Object.new
     vm.stubs(:name).returns('some_vm')
     vm.stubs(:id).returns('123456')
@@ -360,6 +363,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update boolean attribute set_console_password for Libvirt compute resource" do
+    skip_without_libvirt
     cr = compute_resources(:one)
     put :update, params: { :id => cr.id, :compute_resource => { :set_console_password => true } }
     assert_response :success
@@ -402,6 +406,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with valid name" do
+    skip_without_libvirt
     name = RFauxFactory.gen_alpha
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:name => name } }
     assert_response :success
@@ -409,6 +414,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with vnc display type" do
+    skip_without_libvirt
     display_type = "vnc"
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:display_type => display_type } }
     assert_response :success
@@ -416,6 +422,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with spice display type" do
+    skip_without_libvirt
     display_type = "spice"
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:display_type => display_type } }
     assert_response :success
@@ -423,6 +430,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with valid url" do
+    skip_without_libvirt
     new_url = "qemu+tcp://dummy.theforeman.org:16509/system"
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:url => new_url } }
     assert_response :success
@@ -430,6 +438,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with loc" do
+    skip_without_libvirt
     new_location = Location.second
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:location_ids => [new_location.id] } }
     assert_response :success
@@ -439,6 +448,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with org" do
+    skip_without_libvirt
     new_organization = Organization.second
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:organization_ids => [new_organization.id] } }
     assert_response :success
@@ -448,6 +458,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update libvirt compute resource with orgs" do
+    skip_without_libvirt
     new_organizations = [Organization.first, Organization.second, Organization.third]
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:organization_ids => new_organizations.map { |org| org.id } } }
     assert_response :success
@@ -465,12 +476,14 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should not update with already taken name" do
+    skip_without_libvirt
     compute_resource = FactoryBot.create(:libvirt_cr)
     put :update, params: { :id => compute_resource.id, :compute_resource => { :name => compute_resources(:mycompute).name } }
     assert_response :unprocessable_entity, "Can update libvirt compute resource with the name of already existing resource"
   end
 
   test "should not update with empty name" do
+    skip_without_libvirt
     url = ""
     compute_resource = FactoryBot.create(:libvirt_cr)
     put :update, params: { :id => compute_resource.id, :compute_resource => { :url => url } }
@@ -478,6 +491,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should not update with invalid name" do
+    skip_without_libvirt
     url = RFauxFactory.gen_alpha
     compute_resource = FactoryBot.create(:libvirt_cr)
     put :update, params: { :id => compute_resource.id, :compute_resource => { :url => url } }
@@ -486,6 +500,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
 
   context 'libvirt' do
     setup do
+      skip_without_libvirt
       @organization = Organization.first
       @location = Location.first
       @valid_libvirt_attrs = { :name => 'libvirt_compute', :provider => 'libvirt', :url => 'qemu+ssh://root@libvirt.example.com/system' }

--- a/test/controllers/compute_resources_controller_test.rb
+++ b/test/controllers/compute_resources_controller_test.rb
@@ -48,6 +48,7 @@ class ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should create compute resource" do
+    skip_without_libvirt
     role = FactoryBot.build(:role)
     role.add_permissions!([:view_locations, :assign_locations, :edit_locations, :view_organizations, :assign_organizations, :edit_organizations])
     setup_user "create", 'compute_resources', ''
@@ -93,6 +94,7 @@ class ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test 'blank password submitted in compute resource edit form unsets password' do
+    skip_without_libvirt
     setup_user "edit"
     put :update, params: { :id => @compute_resource.to_param, :compute_resource => {:name => "editing_self", :password => ''} }, session: set_session_user
     @compute_resource = ComputeResource.unscoped.find(@compute_resource.id)
@@ -124,6 +126,7 @@ class ComputeResourcesControllerTest < ActionController::TestCase
   end
 
   test "should update compute resource" do
+    skip_without_libvirt
     setup_user "edit"
     put :update, params: { :id => @compute_resource.to_param, :compute_resource => {:name => "editing_self"} }, session: set_session_user
     assert_redirected_to compute_resources_path

--- a/test/controllers/compute_resources_vms_controller_test.rb
+++ b/test/controllers/compute_resources_vms_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ComputeResourcesVmsControllerTest < ActionController::TestCase
   setup do
+    skip_without_libvirt
     @compute_resource = compute_resources(:mycompute)
     @your_compute_resource = compute_resources(:yourcompute)
     get_test_vm

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -143,6 +143,8 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   context "with libvirt" do
+    setup { skip_without_libvirt }
+
     let(:other_libvirt_compute_resource) do
       FactoryBot.create(:libvirt_cr, :locations => [taxonomies(:location2)])
     end
@@ -1277,6 +1279,7 @@ class HostsControllerTest < ActionController::TestCase
 
   context 'Fog.mock!' do
     setup do
+      skip_without_libvirt
       Fog.mock!
     end
 

--- a/test/controllers/key_pairs_controller_test.rb
+++ b/test/controllers/key_pairs_controller_test.rb
@@ -11,6 +11,7 @@ class KeyPairsControllerTest < ActionController::TestCase
   end
 
   test "cr without key_pair should not get index" do
+    skip_without_libvirt
     compute_resource = FactoryBot.create(:libvirt_cr)
     get :index, params: { :compute_resource_id => compute_resource.to_param }, session: set_session_user
     assert_response :not_found

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -1,3 +1,10 @@
+# Hosts on a compute resource default to libvirt, fall back to another provider
+# that also provides the MAC address so such hosts can still be built when libvirt
+# is unavailable. See libvirt_available? for the CI behaviour.
+def compute_resource_factory_name
+  libvirt_available? ? :libvirt_cr : :vmware_cr
+end
+
 FactoryBot.define do
   factory :compute_resource do
     sequence(:name) { |n| "compute_resource#{n}" }

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -428,7 +428,7 @@ FactoryBot.define do
         # add taxonomy overrides in case it's set in the host object
         taxonomies[:locations] = [location] unless location.nil?
         taxonomies[:organizations] = [organization] unless organization.nil?
-        FactoryBot.create(:libvirt_cr, taxonomies)
+        FactoryBot.create(compute_resource_factory_name, taxonomies)
       end
       domain
       subnet do
@@ -455,7 +455,7 @@ FactoryBot.define do
         # add taxonomy overrides in case it's set in the host object
         taxonomies[:locations] = [location] unless location.nil?
         taxonomies[:organizations] = [organization] unless organization.nil?
-        FactoryBot.create(:libvirt_cr, taxonomies)
+        FactoryBot.create(compute_resource_factory_name, taxonomies)
       end
       subnet do
         overrides = {:dns => FactoryBot.create(:dns_smart_proxy)}
@@ -486,7 +486,7 @@ FactoryBot.define do
         # add taxonomy overrides in case it's set in the host object
         taxonomies[:locations] = [location] unless location.nil?
         taxonomies[:organizations] = [organization] unless organization.nil?
-        FactoryBot.create(:libvirt_cr, taxonomies)
+        FactoryBot.create(compute_resource_factory_name, taxonomies)
       end
       subnet6 do
         overrides = {:dns => FactoryBot.create(:dns_smart_proxy)}
@@ -661,7 +661,7 @@ FactoryBot.define do
     end
 
     trait :with_compute_resource do
-      compute_resource { FactoryBot.create(:compute_resource, :libvirt) }
+      compute_resource { FactoryBot.create(compute_resource_factory_name) }
     end
 
     trait :with_config_group do

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -1,7 +1,7 @@
 require 'integration_test_helper'
 require 'integration/shared/host_finders'
 require 'integration/shared/host_orchestration_stubs'
-require 'fog/libvirt/models/compute/node'
+require 'fog/libvirt/models/compute/node' if Foreman::Model::Libvirt.available?
 
 class HostJSTest < IntegrationTestWithJavascript
   # intermittent failures:
@@ -18,6 +18,7 @@ class HostJSTest < IntegrationTestWithJavascript
   include HostOrchestrationStubs
 
   before do
+    skip_without_libvirt
     as_admin { @host = FactoryBot.create(:host, :managed) }
     Fog.mock!
     Foreman::Model::Libvirt.any_instance.stubs(:hypervisor).returns(Fog::Libvirt::Compute::Node.new(:cpus => 4))

--- a/test/models/compute_attribute_test.rb
+++ b/test/models/compute_attribute_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ComputeAttributeTest < ActiveSupport::TestCase
   setup do
+    skip_without_libvirt
     Fog.mock!
     User.current = users :admin
   end

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -13,6 +13,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
   end
 
   test "password is saved encrypted when updated" do
+    skip_without_libvirt
     compute_resource = compute_resources(:one)
     compute_resource.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
     compute_resource.password = "123456"
@@ -55,18 +56,21 @@ class ComputeResourceTest < ActiveSupport::TestCase
   end
 
   test "attrs[:setpw] is set to 1 if compute resource is Libvirt" do
+    skip_without_libvirt
     cr = compute_resources(:mycompute)
     assert cr.update(:set_console_password => 1)
     assert_equal 1, cr.attrs[:setpw]
   end
 
   test "attrs[:setpw] is set to 0 rather than nil if compute resource is Libvirt" do
+    skip_without_libvirt
     cr = compute_resources(:mycompute)
     assert cr.update(:set_console_password => nil)
     assert_equal 0, cr.attrs[:setpw]
   end
 
   test "libvirt vm_instance_defaults should contain the stored display type" do
+    skip_without_libvirt
     cr = compute_resources(:mycompute)
     cr.display_type = 'VNC'
     assert_equal 'vnc', cr.send(:vm_instance_defaults)['display']['type']
@@ -207,6 +211,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
   end
 
   test "description supports more than 255 characters" do
+    skip_without_libvirt
     description = "a" * 300
     assert (description.length > 255)
     cr = compute_resources(:mycompute)
@@ -272,6 +277,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
     end
 
     test "returns vm attributes without id" do
+      skip_without_libvirt
       @vm.stubs(:volumes).returns([@cr.new_volume(name: 'disk1'), @cr.new_volume(name: 'disk2')])
 
       expected_attrs = {:cpus => 5,

--- a/test/models/compute_resources/libvirt_test.rb
+++ b/test/models/compute_resources/libvirt_test.rb
@@ -4,6 +4,10 @@ require 'models/compute_resources/compute_resource_test_helpers'
 class Foreman::Model::LibvirtTest < ActiveSupport::TestCase
   include ComputeResourceTestHelpers
 
+  setup do
+    skip_without_libvirt
+  end
+
   should validate_presence_of(:url)
   should allow_values(*valid_name_list).for(:name)
   should allow_values(*valid_name_list).for(:description)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2388,6 +2388,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "compute attributes are populated by hardware profile passed to host" do
+    skip_without_libvirt
     resource = FactoryBot.create(:libvirt_cr)
     profile = FactoryBot.create(:compute_profile)
     attribute = FactoryBot.create(:compute_attribute, :compute_resource => resource, :compute_profile => profile)
@@ -2989,6 +2990,7 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test 'should take new hostgroup if hostgroup_id present' do
+      skip_without_libvirt
       host = FactoryBot.build_stubbed(:host, :managed, :with_hostgroup)
       new_compute_resource = FactoryBot.create(:compute_resource, :libvirt)
       new_hostgroup = FactoryBot.create(:hostgroup, compute_resource: new_compute_resource)
@@ -3001,6 +3003,7 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test 'should take new hostgroup if hostgroup_name present' do
+      skip_without_libvirt
       host = FactoryBot.build_stubbed(:host, :managed, :with_hostgroup)
       new_compute_resource = FactoryBot.create(:compute_resource, :libvirt)
       new_hostgroup = FactoryBot.create(:hostgroup, compute_resource: new_compute_resource)
@@ -3013,6 +3016,7 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test 'should take old hostgroup if hostgroup not updated' do
+      skip_without_libvirt
       hostgroup = FactoryBot.create(:hostgroup, :with_compute_resource)
       compute_resource = FactoryBot.create(:compute_resource, :libvirt)
       host = FactoryBot.build_stubbed(:host, :managed, hostgroup: hostgroup, compute_resource: compute_resource)
@@ -3046,6 +3050,7 @@ class HostTest < ActiveSupport::TestCase
     end
 
     test 'should inherit attribute value, if not set explicitly' do
+      skip_without_libvirt
       host = FactoryBot.build_stubbed(:host, :managed, :with_hostgroup)
       compute_resource = FactoryBot.create(:compute_resource, :libvirt)
       host.hostgroup.compute_resource = compute_resource

--- a/test/unit/compute_resource_host_importer_test.rb
+++ b/test/unit/compute_resource_host_importer_test.rb
@@ -74,6 +74,7 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
   end
 
   context 'on libvirt' do
+    setup { skip_without_libvirt }
     let(:compute_resource) { FactoryBot.build(:libvirt_cr) }
     let(:uuid) { '6695eb01-f6a4-8304-79aa-97f2502e193f' }
 


### PR DESCRIPTION
As mentioned in https://github.com/theforeman/foremanctl/pull/710, application tests shouldn't be dependent on optional system dependency. The goal is to skip all the tests dependent on libvirt if libvirt isn't available.
