### PR TITLE
Fixes #39335 - Preload authorizer filter permissions

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -52,7 +52,9 @@ class Authorizer
                                                               "OR (#{locations})",
                                                           *values]).distinct
 
-    all_filters = all_filters.reorder(nil).to_a # load all records, so #empty? does not call extra COUNT(*) query
+    # Load all records, so #empty? does not call an extra COUNT(*) query, and preload
+    # associations used by Filter#resource_type to avoid per-filter queries.
+    all_filters = all_filters.preload(:filterings => :permission).reorder(nil).to_a
     Foreman::Logging.logger('permissions').debug do
       all_filters.map do |f|
         "filter with role_id: #{f.role_id} limited: #{f.search.present?} search: #{f.search} taxonomy_search: #{f.taxonomy_search}"

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -328,6 +328,20 @@ class AuthorizerTest < ActiveSupport::TestCase
     assert_empty auth.find_collection(Host::Managed, permission: :view_hosts)
   end
 
+  test "#find_collection preloads filterings and permissions" do
+    permission = Permission.find_by_name('view_domains')
+    FactoryBot.create_list(:role, 2).each do |role|
+      FactoryBot.create(:user_user_role, :owner => @user, :role => role)
+      FactoryBot.create(:filter, :role => role, :permissions => [permission])
+    end
+    @user.reload
+    auth = Authorizer.new(@user)
+
+    assert_sql_queries(2, /SELECT .* FROM "(?:filterings|permissions)"/) do
+      auth.find_collection(Domain, :permission => :view_domains)
+    end
+  end
+
   describe '#find_collection' do
     context 'using joined_on option' do
       test 'allows filtering on associations that do not match association class' do


### PR DESCRIPTION
`Filter#resource_type` reads the first filtering and its permission while authorization scopes are built. With multiple matching filters, those associations were loaded separately for every filter.

Preload filterings and permissions with the filter collection so the association query count remains constant. Add a regression test with multiple roles that verifies the associations are loaded in two queries.

https://projects.theforeman.org/issues/39335

Assisted-By: Codex 5.6 Sol High