### PR TITLE
Fixes #39667 - Remove some deprecated code

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -67,11 +67,6 @@ module ReactjsHelper
     end
   end
 
-  def css_tags_for(requested_plugins)
-    Foreman::Deprecation.deprecation_warning('3.12', '`css_tags_for` is deprecated, No need to load CSS separately, since it should be referenced from the corresponding JS file.')
-    []
-  end
-
   def locale_js_tags
     locale = FastGettext.locale
     ::Foreman::Plugin.all.filter_map do |plugin|

--- a/app/services/owner_classifier.rb
+++ b/app/services/owner_classifier.rb
@@ -1,8 +1,4 @@
 class OwnerClassifier
-  def initialize(id_and_type)
-    @id_and_type = id_and_type
-  end
-
   def self.classify_owner(id_and_type)
     return nil if id_and_type.blank?
 
@@ -10,12 +6,6 @@ class OwnerClassifier
 
     owner_type = id_and_type.end_with?('Users') ? User : Usergroup
     owner_type.find(id_and_type.to_i)
-  end
-
-  def user_or_usergroup
-    Foreman::Deprecation.deprecation_warning("3.12", "`user_or_usergroup` is deprecated, use `classify_owner` instead.")
-
-    OwnerClassifier.classify_owner(@id_and_type)
   end
 
   def self.validate_input_format!(id_and_type)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,5 @@
 #
 # Please ensure that all templates are submitted to community-templates, then they will be synced in.
 
-# define all helpers here
-def format_errors(model = nil)
-  Foreman::Deprecation.deprecation_warning('3.4', '`format_errors` is deprecated, use `SeedHelper.format_errors(model)` instead.')
-  SeedHelper.format_errors(model)
-end
-
 seeder = ForemanSeeder.new
 seeder.execute

--- a/test/unit/owner_classifier_test.rb
+++ b/test/unit/owner_classifier_test.rb
@@ -22,14 +22,4 @@ class OwnerClassifierTest < ActiveSupport::TestCase
     id_and_type = "5-UsErS"
     assert_raises(ArgumentError) { OwnerClassifier.classify_owner(id_and_type) }
   end
-
-  test "Deprecated method: user_or_usergroup should return user if id_and_type is a user" do
-    user = FactoryBot.create(:user)
-    id_and_type = user.id_and_type
-
-    assert_deprecated do
-      owner = OwnerClassifier.new(id_and_type).user_or_usergroup
-      assert_equal user, owner
-    end
-  end
 end


### PR DESCRIPTION
This is definitely not everything, only taking a look on the easy ones. Briefly tested locally, let's see what CI says.

https://community.theforeman.org/t/remove-foreman-deprecations-for-5-0-in-develop-core-plugins/47377

Edit: I was able to grep some instances of deprecated methods in some plugins, taking a deeper look.