### PR TITLE
Add a scoped search <-> patternfly chip component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SearchBar/README.md
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/README.md
@@ -1,0 +1,100 @@
+# SearchBar Component
+
+## Overview
+
+The SearchBar component provides search functionality with autocomplete and visual filter display using PatternFly chips.
+
+## Features
+
+- Text-based search input with autocomplete
+- Visual representation of filters as PatternFly chips
+- Bidirectional conversion between scoped search queries and chips
+- Click to remove individual filters
+- Bookmark support
+
+## Quick Start
+
+### Basic Usage
+
+The SearchBar is already integrated into `TableIndexPage`, so any page using that component automatically gets chip functionality.
+
+```javascript
+import TableIndexPage from '../PF4/TableIndexPage/TableIndexPage';
+
+<TableIndexPage
+  apiUrl="/api/models"
+  controller="models"
+  header="Hardware Models"
+/>
+```
+
+### Standalone Usage
+
+```javascript
+import SearchBar from '../SearchBar';
+
+<SearchBar
+  data={{
+    autocomplete: {
+      url: '/api/models/auto_complete_search',
+      searchQuery: ''
+    },
+    controller: 'models'
+  }}
+  onSearch={(query) => console.log(query)}
+/>
+```
+
+## Files
+
+- `index.js` - Main SearchBar component
+- `SearchAutocomplete.js` - Autocomplete input component
+- `SearchChips.js` - Chip display component
+- `ScopedSearchParser.js` - Query parsing utilities
+- `AutoCompleteMenu.js` - Autocomplete dropdown menu
+- `SearchBar.scss` - Component styles
+
+## Documentation
+
+For complete implementation details, see:
+- **[SEARCH_CHIPS_IMPLEMENTATION.md](./SEARCH_CHIPS_IMPLEMENTATION.md)** - Full implementation guide
+
+## Testing
+
+```bash
+npm test -- SearchBar.test.js
+npm test -- ScopedSearchParser.test.js
+```
+
+## Examples
+
+### Simple Search
+```
+name = production
+```
+Displays: [`name = production`]
+
+### Multiple Filters
+```
+name ~ prod and status != pending
+```
+Displays: [`name contains prod`] [`status ≠ pending`]
+
+### Quoted Values
+```
+description = "production environment"
+```
+Displays: [`description = production environment`]
+
+## Supported Operators
+
+- `=` equals
+- `!=` not equals
+- `>` greater than
+- `<` less than
+- `>=` greater than or equal
+- `<=` less than or equal
+- `~` contains
+- `!~` not contains
+- `^` in list
+- `!^` not in list

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SEARCH_CHIPS_IMPLEMENTATION.md
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SEARCH_CHIPS_IMPLEMENTATION.md
@@ -1,0 +1,557 @@
+# Scoped Search to PatternFly Chips - Implementation Documentation
+
+## Overview
+
+This implementation provides bidirectional conversion between scoped search query strings and PatternFly Chip components, improving the user experience by providing visual representations of active search filters.
+
+### Jira Issue
+**SAT-39885**: [Proton] Use AI to write a React component that converts scoped search queries <> Patternfly chip
+
+### MVP Scope
+- Show chips on list pages using scoped search (All Hosts list, Hardware Models)
+- Update the generic SearchBar component to display chips
+- Bidirectional conversion between query strings and chips
+- Documentation
+
+## Architecture
+
+### Components Created
+
+1. **ScopedSearchParser.js** - Utility functions for parsing and converting search queries
+2. **SearchChips.js** - React component for displaying filters as PatternFly chips
+3. **Updated SearchBar/index.js** - Integration of chips into the existing SearchBar
+
+### Data Flow
+
+```
+User Input (Search Query String)
+          ↓
+  parseScopedSearchQuery()
+          ↓
+  Array of Filter Objects
+          ↓
+    SearchChips Component
+          ↓
+  PatternFly Chip Display
+          ↓
+  User Removes Chip
+          ↓
+  removeFilterFromQuery()
+          ↓
+  Updated Search Query String
+          ↓
+  API Request with New Query
+```
+
+## Component Details
+
+### 1. ScopedSearchParser.js
+
+Located at: `webpack/assets/javascripts/react_app/components/SearchBar/ScopedSearchParser.js`
+
+#### Purpose
+Provides utility functions for parsing scoped search query strings and converting between query strings and filter objects.
+
+#### Exported Functions
+
+##### `parseScopedSearchQuery(queryString)`
+Parses a scoped search query string into an array of filter objects.
+
+**Parameters:**
+- `queryString` (string): Scoped search query (e.g., "name = test and status != pending")
+
+**Returns:**
+- Array of filter objects: `[{ field, operator, value }, ...]`
+
+**Example:**
+```javascript
+import { parseScopedSearchQuery } from './ScopedSearchParser';
+
+const filters = parseScopedSearchQuery('name = prod and status != pending');
+// Returns: [
+//   { field: 'name', operator: '=', value: 'prod' },
+//   { field: 'status', operator: '!=', value: 'pending' }
+// ]
+```
+
+**Supported Operators:**
+- `=` - equals
+- `!=` - not equals
+- `>` - greater than
+- `<` - less than
+- `>=` - greater than or equal
+- `<=` - less than or equal
+- `~` - contains (LIKE)
+- `!~` - does not contain
+- `^` - in list
+- `!^` - not in list
+
+**Supported Logical Operators:**
+- `and` - logical AND (default when joining filters)
+- `or` - logical OR
+- `not` - logical NOT
+- `has` - has field
+
+##### `convertFiltersToQuery(filters)`
+Converts an array of filter objects back to a scoped search query string.
+
+**Parameters:**
+- `filters` (Array): Array of filter objects
+
+**Returns:**
+- String: Scoped search query string
+
+**Example:**
+```javascript
+import { convertFiltersToQuery } from './ScopedSearchParser';
+
+const filters = [
+  { field: 'name', operator: '=', value: 'test' },
+  { field: 'status', operator: '!=', value: 'pending' }
+];
+
+const query = convertFiltersToQuery(filters);
+// Returns: "name = test and status != pending"
+```
+
+##### `removeFilterFromQuery(queryString, filterToRemove)`
+Removes a specific filter from a query string.
+
+**Parameters:**
+- `queryString` (string): Original query string
+- `filterToRemove` (object): Filter object to remove
+
+**Returns:**
+- String: Updated query string without the removed filter
+
+**Example:**
+```javascript
+import { removeFilterFromQuery } from './ScopedSearchParser';
+
+const query = 'name = test and status = active';
+const filterToRemove = { field: 'name', operator: '=', value: 'test' };
+
+const newQuery = removeFilterFromQuery(query, filterToRemove);
+// Returns: "status = active"
+```
+
+##### `addFilterToQuery(queryString, newFilter)`
+Adds a new filter to an existing query string.
+
+**Parameters:**
+- `queryString` (string): Original query string
+- `newFilter` (object): Filter object to add
+
+**Returns:**
+- String: Updated query string with the new filter
+
+**Example:**
+```javascript
+import { addFilterToQuery } from './ScopedSearchParser';
+
+const query = 'name = test';
+const newFilter = { field: 'status', operator: '=', value: 'active' };
+
+const newQuery = addFilterToQuery(query, newFilter);
+// Returns: "name = test and status = active"
+```
+
+##### `updateFilterInQuery(queryString, oldFilter, newFilter)`
+Updates an existing filter in a query string.
+
+**Parameters:**
+- `queryString` (string): Original query string
+- `oldFilter` (object): Filter to replace
+- `newFilter` (object): New filter (null to remove)
+
+**Returns:**
+- String: Updated query string
+
+### 2. SearchChips.js
+
+Located at: `webpack/assets/javascripts/react_app/components/SearchBar/SearchChips.js`
+
+#### Purpose
+Displays parsed search filters as PatternFly Chip components with remove functionality.
+
+#### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `filters` | Array | No | `[]` | Array of filter objects to display |
+| `onRemoveFilter` | Function | Yes | - | Callback when a chip is removed |
+| `categoryName` | String | No | `'Active filters'` | Label for the chip group |
+
+#### Filter Object Structure
+```javascript
+{
+  field: string,      // Field name (e.g., 'name', 'status')
+  operator: string,   // Operator (e.g., '=', '!=', '~')
+  value: string       // Filter value
+}
+```
+
+#### Example Usage
+```javascript
+import SearchChips from './SearchChips';
+
+const filters = [
+  { field: 'name', operator: '=', value: 'production' },
+  { field: 'status', operator: '!=', value: 'pending' }
+];
+
+const handleRemove = (filter) => {
+  console.log('Removed filter:', filter);
+  // Update search query
+};
+
+<SearchChips
+  filters={filters}
+  onRemoveFilter={handleRemove}
+  categoryName="Search Filters"
+/>
+```
+
+#### Chip Display Format
+Chips are displayed with friendly operator labels:
+- `=` → `=`
+- `!=` → `≠`
+- `>=` → `≥`
+- `<=` → `≤`
+- `~` → `contains`
+- `!~` → `not contains`
+- `^` → `in`
+- `!^` → `not in`
+
+Example chip text: `name = production`, `status ≠ pending`
+
+### 3. SearchBar Integration
+
+Located at: `webpack/assets/javascripts/react_app/components/SearchBar/index.js`
+
+#### Changes Made
+
+1. **Import Statements Added:**
+```javascript
+import SearchChips from './SearchChips';
+import {
+  parseScopedSearchQuery,
+  removeFilterFromQuery,
+} from './ScopedSearchParser';
+```
+
+2. **Parsing Logic:**
+```javascript
+const filters = useMemo(() => parseScopedSearchQuery(search), [search]);
+```
+
+3. **Remove Handler:**
+```javascript
+const handleRemoveFilter = filterToRemove => {
+  const newQuery = removeFilterFromQuery(search, filterToRemove);
+  _onSearchChange(newQuery);
+  if (onSearch) _onSearch(newQuery);
+};
+```
+
+4. **Component Rendering:**
+```jsx
+<SearchChips filters={filters} onRemoveFilter={handleRemoveFilter} />
+```
+
+#### Updated Layout
+The SearchBar now displays:
+1. Search input with autocomplete (top)
+2. Search chips below input (new)
+3. Bookmarks dropdown (right side)
+
+### 4. Styling Updates
+
+Located at: `webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.scss`
+
+#### Changes Made
+
+```scss
+.foreman-search-bar {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;                              // Allow chips to wrap
+  gap: var(--pf-v5-global--spacer--sm);        // Spacing between elements
+
+  .search-chips-container {
+    width: 100%;
+    margin-top: var(--pf-v5-global--spacer--sm); // Space above chips
+  }
+}
+```
+
+## Testing
+
+### Unit Tests
+
+Test file: `ScopedSearchParser.test.js`
+
+The parser has comprehensive test coverage including:
+- Simple equality filters
+- Multiple filters with AND/OR
+- Quoted values
+- All supported operators
+- Edge cases (empty queries, mixed spacing)
+- Round-trip conversion (parse → convert → parse)
+
+To run tests:
+```bash
+npm test -- ScopedSearchParser.test.js
+```
+
+### Manual Testing
+
+#### Test on Hosts Page
+1. Navigate to **All Hosts** (`/hosts`)
+2. Enter search query: `name = test`
+3. Verify chip appears: `name = test`
+4. Click the X on the chip
+5. Verify chip is removed and search clears
+6. Enter complex query: `name ~ prod and status = active`
+7. Verify two chips appear
+8. Remove one chip, verify query updates correctly
+
+#### Test on Hardware Models Page
+1. Navigate to **Hardware Models** (`/models`)
+2. Enter search query: `vendor_class = Dell`
+3. Verify chip appears
+4. Test autocomplete integration
+5. Verify chip updates when query changes
+
+### Example Test Queries
+
+Simple queries:
+- `name = production`
+- `status != pending`
+- `count > 10`
+
+Complex queries:
+- `name ~ prod and status = active`
+- `created >= "2024-01-01" and status != archived`
+- `vendor_class = Dell and hardware_model ~ PowerEdge`
+
+Quoted values:
+- `name = "test server"`
+- `description ~ "production environment"`
+
+## Current Limitations
+
+### 1. Read-Only Chips
+Currently, chips can only be removed, not edited inline. To change a filter value, users must:
+- Remove the chip
+- Re-enter the search query with new values
+
+**Future Enhancement:** Add inline editing or click-to-edit functionality.
+
+### 2. Logical Operators Display
+The current implementation joins all filters with `and` when converting back to query strings. While the parser recognizes `or`, `not`, and `has` operators, they are:
+- Ignored during parsing (treated as separators)
+- Not preserved in round-trip conversion
+- Not visible in chip display
+
+**Example:**
+```
+Input:  "name = test or name = prod"
+Parsed: [{ field: 'name', operator: '=', value: 'test' },
+         { field: 'name', operator: '=', value: 'prod' }]
+Output: "name = test and name = prod"
+```
+
+**Future Enhancement:** Preserve logical operators and display them in chip groups.
+
+### 3. No Grouping/Nesting Support
+Complex queries with parentheses are not supported:
+- `(name = test or name = prod) and status = active`
+
+The parser will extract the filters but ignore the grouping.
+
+**Future Enhancement:** Add support for nested filter groups with visual grouping in chips.
+
+### 4. Value Type Inference
+All values are treated as strings. The parser doesn't distinguish between:
+- Numbers: `count > 10`
+- Dates: `created >= "2024-01-01"`
+- Booleans: `enabled = true`
+- Strings: `name = "test"`
+
+**Future Enhancement:** Add type inference and validation based on field definitions.
+
+### 5. No Field Validation
+The parser accepts any field name without validation against the model's scoped search configuration.
+
+**Future Enhancement:** Integrate with backend field definitions to:
+- Validate field names
+- Provide field-specific operators
+- Show available values for enumerated fields
+
+## Integration Points
+
+### Automatic Integration
+The SearchChips component is automatically available on any page using:
+- `TableIndexPage` component
+- `SearchBar` component
+
+This includes (but is not limited to):
+- All Hosts (`/hosts`)
+- Hardware Models (`/models`)
+- Any other index pages using the generic table component
+
+### No Additional Configuration Required
+Pages using `TableIndexPage` or `SearchBar` will automatically get chip functionality without any code changes.
+
+## Future Enhancements
+
+### High Priority
+1. **Inline Chip Editing**
+   - Click chip to edit filter
+   - Dropdown for operator selection
+   - Type-ahead for values
+
+2. **Field Autocomplete Integration**
+   - Show available fields in autocomplete
+   - Display field-specific operators
+   - Suggest values for known fields
+
+3. **Visual Logical Operators**
+   - Show `and`/`or` between chips
+   - Group related filters visually
+   - Drag-and-drop to reorder
+
+### Medium Priority
+4. **Type-Aware Validation**
+   - Date pickers for date fields
+   - Number inputs for numeric fields
+   - Dropdowns for enumerated values
+
+5. **Saved Filter Sets**
+   - Save common filter combinations
+   - Quick-apply saved filters
+   - Share filters with team
+
+6. **Advanced Query Builder**
+   - Visual query builder UI
+   - Drag-and-drop filter creation
+   - Nested condition support
+
+### Low Priority
+7. **Chip Keyboard Navigation**
+   - Tab between chips
+   - Delete key to remove
+   - Arrow keys to navigate
+
+8. **Export/Import Filters**
+   - Copy filters as JSON
+   - Share via URL parameters
+   - Import from clipboard
+
+## Performance Considerations
+
+### Parsing Performance
+The parser uses a single-pass algorithm with O(n) complexity where n is the query string length. Performance impact is negligible for typical query lengths (<1000 characters).
+
+### Re-rendering Optimization
+Uses `useMemo` to cache parsed filters and only re-parse when the search query changes.
+
+### Large Filter Sets
+Current implementation has no pagination or virtualization for chips. For queries with >20 filters, consider:
+- Collapsible chip groups
+- "Show more" functionality
+- Virtual scrolling for chip containers
+
+## Troubleshooting
+
+### Chips Not Appearing
+1. Check browser console for JavaScript errors
+2. Verify search query is valid scoped search syntax
+3. Ensure PatternFly CSS is loaded
+4. Check that SearchBar is receiving the search prop
+
+### Incorrect Parsing
+1. Verify operator spacing in query
+2. Check for special characters in values
+3. Use quotes around values with spaces
+4. Ensure logical operators are lowercase
+
+### Styling Issues
+1. Check PatternFly version compatibility (requires v5.4+)
+2. Verify SCSS compilation
+3. Check for CSS conflicts with custom styles
+4. Inspect element classes match PatternFly naming
+
+## Code Examples
+
+### Custom Implementation (Outside TableIndexPage)
+
+If you need to use SearchChips in a custom component:
+
+```javascript
+import React, { useState, useMemo } from 'react';
+import SearchChips from '../SearchBar/SearchChips';
+import {
+  parseScopedSearchQuery,
+  removeFilterFromQuery,
+} from '../SearchBar/ScopedSearchParser';
+
+const MyCustomSearch = () => {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filters = useMemo(
+    () => parseScopedSearchQuery(searchQuery),
+    [searchQuery]
+  );
+
+  const handleRemoveFilter = filterToRemove => {
+    const newQuery = removeFilterFromQuery(searchQuery, filterToRemove);
+    setSearchQuery(newQuery);
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={searchQuery}
+        onChange={e => setSearchQuery(e.target.value)}
+        placeholder="Enter search query..."
+      />
+      <SearchChips
+        filters={filters}
+        onRemoveFilter={handleRemoveFilter}
+      />
+    </div>
+  );
+};
+```
+
+### Adding Custom Chip Actions
+
+To add custom actions beyond remove:
+
+```javascript
+import React from 'react';
+import { Chip, ChipGroup } from '@patternfly/react-core';
+
+const CustomSearchChips = ({ filters, onRemove, onEdit }) => (
+  <ChipGroup categoryName="Filters">
+    {filters.map((filter, index) => (
+      <Chip
+        key={index}
+        onClick={() => onRemove(filter)}
+        onAuxClick={() => onEdit(filter)}  // Custom action
+      >
+        {`${filter.field} ${filter.operator} ${filter.value}`}
+      </Chip>
+    ))}
+  </ChipGroup>
+);
+```
+
+## Conclusion
+
+This implementation provides a solid foundation for visual search filter management using PatternFly chips. While there are opportunities for enhancement (inline editing, logical operator preservation, nested queries), the current MVP successfully achieves the goal of improving search UX on the All Hosts and Hardware Models pages.
+
+The modular architecture makes it easy to extend functionality incrementally while maintaining backward compatibility with the existing text-based search interface.

--- a/webpack/assets/javascripts/react_app/components/SearchBar/ScopedSearchParser.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/ScopedSearchParser.js
@@ -1,0 +1,168 @@
+const OPERATORS = ['!=', '!~', '!^', '>=', '<=', '=', '>', '<', '~', '^'];
+const LOGICAL_OPERATORS = ['and', 'or', 'not', 'has'];
+
+const escapeRegExp = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const parseValue = value => {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+};
+
+const formatValue = value => {
+  if (!value) return '""';
+  const stringValue = String(value);
+  if (
+    stringValue.includes(' ') ||
+    stringValue.includes(',') ||
+    stringValue.includes('(') ||
+    stringValue.includes(')')
+  ) {
+    return `"${stringValue.replace(/"/g, '\\"')}"`;
+  }
+  return stringValue;
+};
+
+export const parseScopedSearchQuery = queryString => {
+  if (!queryString || typeof queryString !== 'string') {
+    return [];
+  }
+
+  const filters = [];
+  let currentPos = 0;
+  const query = queryString.trim();
+
+  while (currentPos < query.length) {
+    const remainingQuery = query.substring(currentPos).trim();
+
+    const logicalMatch = LOGICAL_OPERATORS.find(op => {
+      const pattern = new RegExp(`^${escapeRegExp(op)}\\s+`, 'i');
+      return pattern.test(remainingQuery);
+    });
+
+    if (logicalMatch) {
+      currentPos += logicalMatch.length + 1;
+      while (currentPos < query.length && query[currentPos] === ' ') {
+        currentPos++;
+      }
+    } else {
+      let foundFilter = false;
+
+      // eslint-disable-next-line no-unused-vars
+      for (const operator of OPERATORS) {
+        const operatorPattern = new RegExp(
+          `^([^\\s]+)\\s*${escapeRegExp(operator)}\\s*`,
+          'i'
+        );
+        const match = remainingQuery.match(operatorPattern);
+
+        if (match) {
+          const field = match[1];
+          currentPos += match[0].length;
+
+          let value = '';
+          const valueQuery = query.substring(currentPos);
+
+          if (valueQuery[0] === '"' || valueQuery[0] === "'") {
+            const quoteChar = valueQuery[0];
+            let endQuotePos = 1;
+            while (
+              endQuotePos < valueQuery.length &&
+              valueQuery[endQuotePos] !== quoteChar
+            ) {
+              if (
+                valueQuery[endQuotePos] === '\\' &&
+                endQuotePos + 1 < valueQuery.length
+              ) {
+                endQuotePos += 2;
+              } else {
+                endQuotePos++;
+              }
+            }
+            if (endQuotePos < valueQuery.length) {
+              value = valueQuery.substring(0, endQuotePos + 1);
+              currentPos += endQuotePos + 1;
+            } else {
+              value = valueQuery.substring(0, endQuotePos);
+              currentPos += endQuotePos;
+            }
+          } else {
+            const valueMatch = valueQuery.match(/^([^\s]+)/);
+            if (valueMatch) {
+              [, value] = valueMatch;
+              currentPos += value.length;
+            }
+          }
+
+          filters.push({
+            field,
+            operator,
+            value: parseValue(value),
+          });
+
+          foundFilter = true;
+          break;
+        }
+      }
+
+      if (!foundFilter) {
+        currentPos++;
+      }
+
+      while (currentPos < query.length && query[currentPos] === ' ') {
+        currentPos++;
+      }
+    }
+  }
+
+  return filters;
+};
+
+export const convertFiltersToQuery = filters => {
+  if (!Array.isArray(filters) || filters.length === 0) {
+    return '';
+  }
+
+  return filters
+    .map(({ field, operator, value }) => {
+      if (!field || !operator) return '';
+      return `${field} ${operator} ${formatValue(value)}`;
+    })
+    .filter(Boolean)
+    .join(' and ');
+};
+
+export const updateFilterInQuery = (queryString, filterToUpdate, newFilter) => {
+  const filters = parseScopedSearchQuery(queryString);
+  const index = filters.findIndex(
+    f =>
+      f.field === filterToUpdate.field &&
+      f.operator === filterToUpdate.operator &&
+      f.value === filterToUpdate.value
+  );
+
+  if (index !== -1) {
+    if (newFilter) {
+      filters[index] = newFilter;
+    } else {
+      filters.splice(index, 1);
+    }
+  }
+
+  return convertFiltersToQuery(filters);
+};
+
+export const removeFilterFromQuery = (queryString, filterToRemove) =>
+  updateFilterInQuery(queryString, filterToRemove, null);
+
+export const addFilterToQuery = (queryString, newFilter) => {
+  const filters = parseScopedSearchQuery(queryString);
+  filters.push(newFilter);
+  return convertFiltersToQuery(filters);
+};

--- a/webpack/assets/javascripts/react_app/components/SearchBar/ScopedSearchParser.test.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/ScopedSearchParser.test.js
@@ -1,0 +1,214 @@
+import {
+  parseScopedSearchQuery,
+  convertFiltersToQuery,
+  updateFilterInQuery,
+  removeFilterFromQuery,
+  addFilterToQuery,
+} from './ScopedSearchParser';
+
+describe('ScopedSearchParser', () => {
+  describe('parseScopedSearchQuery', () => {
+    it('should parse a simple equality filter', () => {
+      const result = parseScopedSearchQuery('name = test');
+      expect(result).toEqual([{ field: 'name', operator: '=', value: 'test' }]);
+    });
+
+    it('should parse multiple filters with AND', () => {
+      const result = parseScopedSearchQuery('name = test and status != pending');
+      expect(result).toEqual([
+        { field: 'name', operator: '=', value: 'test' },
+        { field: 'status', operator: '!=', value: 'pending' },
+      ]);
+    });
+
+    it('should parse filters with quoted values', () => {
+      const result = parseScopedSearchQuery('name = "test value"');
+      expect(result).toEqual([
+        { field: 'name', operator: '=', value: 'test value' },
+      ]);
+    });
+
+    it('should handle various operators', () => {
+      const operators = ['=', '!=', '>', '<', '>=', '<=', '~', '!~', '^', '!^'];
+      operators.forEach(op => {
+        const result = parseScopedSearchQuery(`field ${op} value`);
+        expect(result).toEqual([{ field: 'field', operator: op, value: 'value' }]);
+      });
+    });
+
+    it('should handle empty query', () => {
+      expect(parseScopedSearchQuery('')).toEqual([]);
+      expect(parseScopedSearchQuery(null)).toEqual([]);
+      expect(parseScopedSearchQuery(undefined)).toEqual([]);
+    });
+
+    it('should parse complex queries', () => {
+      const result = parseScopedSearchQuery(
+        'name ~ prod and status = active and count > 10'
+      );
+      expect(result).toEqual([
+        { field: 'name', operator: '~', value: 'prod' },
+        { field: 'status', operator: '=', value: 'active' },
+        { field: 'count', operator: '>', value: '10' },
+      ]);
+    });
+
+    it('should handle single quotes', () => {
+      const result = parseScopedSearchQuery("name = 'test value'");
+      expect(result).toEqual([
+        { field: 'name', operator: '=', value: 'test value' },
+      ]);
+    });
+
+    it('should handle mixed spacing', () => {
+      const result = parseScopedSearchQuery('name=test and  status  !=  pending');
+      expect(result).toEqual([
+        { field: 'name', operator: '=', value: 'test' },
+        { field: 'status', operator: '!=', value: 'pending' },
+      ]);
+    });
+
+    it('should handle OR operator', () => {
+      const result = parseScopedSearchQuery('name = test or name = prod');
+      expect(result).toEqual([
+        { field: 'name', operator: '=', value: 'test' },
+        { field: 'name', operator: '=', value: 'prod' },
+      ]);
+    });
+
+    it('should handle NOT operator', () => {
+      const result = parseScopedSearchQuery('not name = test');
+      expect(result).toEqual([{ field: 'name', operator: '=', value: 'test' }]);
+    });
+
+    it('should handle HAS operator', () => {
+      const result = parseScopedSearchQuery('has name');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('convertFiltersToQuery', () => {
+    it('should convert simple filter to query', () => {
+      const filters = [{ field: 'name', operator: '=', value: 'test' }];
+      expect(convertFiltersToQuery(filters)).toBe('name = test');
+    });
+
+    it('should convert multiple filters to query with AND', () => {
+      const filters = [
+        { field: 'name', operator: '=', value: 'test' },
+        { field: 'status', operator: '!=', value: 'pending' },
+      ];
+      expect(convertFiltersToQuery(filters)).toBe(
+        'name = test and status != pending'
+      );
+    });
+
+    it('should quote values with spaces', () => {
+      const filters = [{ field: 'name', operator: '=', value: 'test value' }];
+      expect(convertFiltersToQuery(filters)).toBe('name = "test value"');
+    });
+
+    it('should handle empty filters array', () => {
+      expect(convertFiltersToQuery([])).toBe('');
+      expect(convertFiltersToQuery(null)).toBe('');
+      expect(convertFiltersToQuery(undefined)).toBe('');
+    });
+
+    it('should skip invalid filters', () => {
+      const filters = [
+        { field: 'name', operator: '=', value: 'test' },
+        { field: '', operator: '=', value: 'test' },
+        { field: 'status', operator: '', value: 'pending' },
+      ];
+      expect(convertFiltersToQuery(filters)).toBe('name = test');
+    });
+
+    it('should handle various operators', () => {
+      const filters = [{ field: 'count', operator: '>=', value: '10' }];
+      expect(convertFiltersToQuery(filters)).toBe('count >= 10');
+    });
+
+    it('should quote values with commas', () => {
+      const filters = [{ field: 'tags', operator: '=', value: 'a,b,c' }];
+      expect(convertFiltersToQuery(filters)).toBe('tags = "a,b,c"');
+    });
+
+    it('should quote values with parentheses', () => {
+      const filters = [{ field: 'name', operator: '=', value: 'test(1)' }];
+      expect(convertFiltersToQuery(filters)).toBe('name = "test(1)"');
+    });
+  });
+
+  describe('updateFilterInQuery', () => {
+    it('should update an existing filter', () => {
+      const query = 'name = test and status = active';
+      const oldFilter = { field: 'name', operator: '=', value: 'test' };
+      const newFilter = { field: 'name', operator: '=', value: 'prod' };
+      const result = updateFilterInQuery(query, oldFilter, newFilter);
+      expect(result).toBe('name = prod and status = active');
+    });
+
+    it('should remove a filter when newFilter is null', () => {
+      const query = 'name = test and status = active';
+      const filterToRemove = { field: 'name', operator: '=', value: 'test' };
+      const result = updateFilterInQuery(query, filterToRemove, null);
+      expect(result).toBe('status = active');
+    });
+
+    it('should return original query if filter not found', () => {
+      const query = 'name = test';
+      const oldFilter = { field: 'status', operator: '=', value: 'active' };
+      const newFilter = { field: 'status', operator: '=', value: 'pending' };
+      const result = updateFilterInQuery(query, oldFilter, newFilter);
+      expect(result).toBe('name = test');
+    });
+  });
+
+  describe('removeFilterFromQuery', () => {
+    it('should remove a filter from query', () => {
+      const query = 'name = test and status = active and count > 5';
+      const filterToRemove = { field: 'status', operator: '=', value: 'active' };
+      const result = removeFilterFromQuery(query, filterToRemove);
+      expect(result).toBe('name = test and count > 5');
+    });
+
+    it('should handle removing the only filter', () => {
+      const query = 'name = test';
+      const filterToRemove = { field: 'name', operator: '=', value: 'test' };
+      const result = removeFilterFromQuery(query, filterToRemove);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('addFilterToQuery', () => {
+    it('should add a filter to existing query', () => {
+      const query = 'name = test';
+      const newFilter = { field: 'status', operator: '=', value: 'active' };
+      const result = addFilterToQuery(query, newFilter);
+      expect(result).toBe('name = test and status = active');
+    });
+
+    it('should add a filter to empty query', () => {
+      const query = '';
+      const newFilter = { field: 'name', operator: '=', value: 'test' };
+      const result = addFilterToQuery(query, newFilter);
+      expect(result).toBe('name = test');
+    });
+  });
+
+  describe('round-trip conversion', () => {
+    it('should maintain query integrity through parse and convert', () => {
+      const originalQuery = 'name = test and status != pending and count >= 10';
+      const filters = parseScopedSearchQuery(originalQuery);
+      const reconstructedQuery = convertFiltersToQuery(filters);
+      expect(reconstructedQuery).toBe(originalQuery);
+    });
+
+    it('should handle quoted values in round-trip', () => {
+      const originalQuery = 'name = "test value" and status = active';
+      const filters = parseScopedSearchQuery(originalQuery);
+      const reconstructedQuery = convertFiltersToQuery(filters);
+      expect(reconstructedQuery).toBe(originalQuery);
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.scss
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.scss
@@ -19,7 +19,12 @@
     width: unset;
   }
 
-  .pf-v5-c-dropdown { 
+  .pf-v5-c-dropdown {
     width: unset; // just in case Katello overrides it
   }
+}
+
+.search-chips-container {
+  width: 100%;
+  margin-top: var(--pf-v5-global--spacer--sm);
 }

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.test.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.test.js
@@ -81,7 +81,8 @@ describe('SearchBar', () => {
       });
     });
     await waitFor(() => screen.getByText('hardware_model = test'));
-    expect(screen.queryAllByText('hardware_model =')).toHaveLength(1);
+    // Should appear in autocomplete menu and as a chip
+    expect(screen.queryAllByText('hardware_model =')).toHaveLength(2);
     await act(async () => {
       fireEvent.click(screen.getByLabelText('bookmarks dropdown toggle'));
     });

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchChips.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchChips.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Chip, ChipGroup } from '@patternfly/react-core';
+import { translate as __ } from '../../common/I18n';
+import './SearchBar.scss';
+
+const getOperatorLabel = operator => {
+  const operatorLabels = {
+    '=': '=',
+    '!=': '≠',
+    '>': '>',
+    '<': '<',
+    '>=': '≥',
+    '<=': '≤',
+    '~': __('contains'),
+    '!~': __('not contains'),
+    '^': __('in'),
+    '!^': __('not in'),
+  };
+  return operatorLabels[operator] || operator;
+};
+
+export const SearchChips = ({ filters, onRemoveFilter, categoryName }) => {
+  if (!filters || filters.length === 0) {
+    return null;
+  }
+
+  const handleRemove = (_event, filter) => {
+    onRemoveFilter(filter);
+  };
+
+  return (
+    <div className="search-chips-container">
+      <ChipGroup
+        categoryName={categoryName || __('Active filters')}
+        ouiaId="search-chips-group"
+      >
+        {filters.map((filter, index) => {
+          const chipText = `${filter.field} ${getOperatorLabel(
+            filter.operator
+          )} ${filter.value}`;
+          return (
+            <Chip
+              key={`${filter.field}-${filter.operator}-${filter.value}-${index}`}
+              onClick={() => handleRemove(null, filter)}
+              ouiaId={`search-chip-${filter.field}`}
+            >
+              {chipText}
+            </Chip>
+          );
+        })}
+      </ChipGroup>
+    </div>
+  );
+};
+
+SearchChips.propTypes = {
+  filters: PropTypes.arrayOf(
+    PropTypes.shape({
+      field: PropTypes.string.isRequired,
+      operator: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    })
+  ),
+  onRemoveFilter: PropTypes.func.isRequired,
+  categoryName: PropTypes.string,
+};
+
+SearchChips.defaultProps = {
+  filters: [],
+  categoryName: null,
+};
+
+export default SearchChips;

--- a/webpack/assets/javascripts/react_app/components/SearchBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchAutocomplete } from './SearchAutocomplete';
@@ -7,6 +7,11 @@ import Bookmarks from '../PF4/Bookmarks';
 import { changeQuery } from '../../common/urlHelpers';
 import { STATUS } from '../../constants';
 import { noop } from '../../common/helpers';
+import { SearchChips } from './SearchChips';
+import {
+  parseScopedSearchQuery,
+  removeFilterFromQuery,
+} from './ScopedSearchParser';
 
 const SearchBar = ({
   data: {
@@ -54,32 +59,44 @@ const SearchBar = ({
     status === STATUS.ERROR || response?.[0]?.error
       ? response?.[0]?.error || response.message
       : null;
+
+  const filters = useMemo(() => parseScopedSearchQuery(search), [search]);
+
+  const handleRemoveFilter = filterToRemove => {
+    const newQuery = removeFilterFromQuery(search, filterToRemove);
+    _onSearchChange(newQuery);
+    if (onSearch) _onSearch(newQuery);
+  };
+
   return (
-    <div className="foreman-search-bar">
-      <SearchAutocomplete
-        results={
-          Array.isArray(response) && !response?.[0]?.error ? response : []
-        }
-        onSearchChange={_onSearchChange}
-        value={search}
-        onSearch={onSearch && _onSearch}
-        disabled={disabled}
-        error={error}
-        name={name}
-      />
-      {!isEmpty(bookmarks) && (
-        <Bookmarks
-          onBookmarkClick={newSearch => {
-            _onSearchChange(newSearch);
-            if (onSearch) onSearch(newSearch);
-          }}
-          controller={controller}
-          searchQuery={search || ''}
-          bookmarksPosition={bookmarksPosition}
-          {...bookmarks}
+    <>
+      <div className="foreman-search-bar">
+        <SearchAutocomplete
+          results={
+            Array.isArray(response) && !response?.[0]?.error ? response : []
+          }
+          onSearchChange={_onSearchChange}
+          value={search}
+          onSearch={onSearch && _onSearch}
+          disabled={disabled}
+          error={error}
+          name={name}
         />
-      )}
-    </div>
+        {!isEmpty(bookmarks) && (
+          <Bookmarks
+            onBookmarkClick={newSearch => {
+              _onSearchChange(newSearch);
+              if (onSearch) onSearch(newSearch);
+            }}
+            controller={controller}
+            searchQuery={search || ''}
+            bookmarksPosition={bookmarksPosition}
+            {...bookmarks}
+          />
+        )}
+      </div>
+      <SearchChips filters={filters} onRemoveFilter={handleRemoveFilter} />
+    </>
   );
 };
 


### PR DESCRIPTION
As a agentic development research item, I have attempted to use Claude Code to write a component that will parameterize the scoped search query and add patternfly chips of the filter variables.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
