### PR TITLE
Fixes #39688 - replace enzyme tests with RTL for RegistrationCommandsPage helpers

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/helpers.test.js
@@ -1,16 +1,21 @@
 import React from 'react';
-import { shallow, render } from 'enzyme'
-import { FormSelectOption } from '@patternfly/react-core';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
-import { emptyOption, validatedOS, osHelperText } from '../RegistrationCommandsPageHelpers'
+import { emptyOption, validatedOS, osHelperText } from '../RegistrationCommandsPageHelpers';
 
 describe('emptyOption', () => {
   it('when length == 0', () => {
-    expect(emptyOption(0)).toEqual(<FormSelectOption label="Nothing to select." value="" />);
+    render(<select>{emptyOption(0)}</select>);
+
+    expect(screen.getByText('Nothing to select.')).toBeInTheDocument();
   });
 
   it('when length > 0', () => {
-    expect(emptyOption(23)).toEqual(<FormSelectOption label="" value="" />);
+    render(<select>{emptyOption(23)}</select>);
+
+    expect(screen.getByRole('option')).toBeInTheDocument();
+    expect(screen.queryByText('Nothing to select.')).not.toBeInTheDocument();
   });
 });
 
@@ -20,42 +25,91 @@ describe('validatedOS', () => {
   });
 
   it('with template', () => {
-    expect(validatedOS(1, {name: 'test'})).toEqual('success');
+    expect(validatedOS(1, { name: 'test' })).toEqual('success');
   });
 
   it('without template', () => {
-    expect(validatedOS(1, {name: ''})).toEqual('error');
+    expect(validatedOS(1, { name: '' })).toEqual('error');
   });
 });
 
 describe('osHelperText', () => {
   it('OS with template', () => {
-    const wrapper = shallow(osHelperText(1, [], null, [], {name: 'test'}));
-    expect(wrapper.find('span').text()).toMatch(/Initial configuration template: test/)
+    render(
+      osHelperText(1, [], null, [], { name: 'test', path: '/templates/1' })
+    );
+
+    expect(screen.getByText(/Initial configuration template/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'test' })).toHaveAttribute(
+      'href',
+      '/templates/1'
+    );
   });
 
   it('OS without template', () => {
-    const wrapper = shallow(osHelperText(1, [], null, [], {}));
-    expect(wrapper.find('span').text()).toMatch(/does not have assigned host_init_config template/)
+    render(osHelperText(1, [], null, [], { os_path: '/operatingsystems/1' }));
+
+    expect(
+      screen.getByText(/does not have assigned host_init_config template/)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Operating system' })).toHaveAttribute(
+      'href',
+      '/operatingsystems/1'
+    );
   });
 
   it('for host group with OS with template', () => {
-    const wrapper = render(osHelperText(null, [{id: 23}], 1, [{ id: 1, inherited_operatingsystem_id: 23 }], { name: 'test'}));
+    render(
+      osHelperText(
+        null,
+        [{ id: 23, title: 'RHEL 8' }],
+        1,
+        [{ id: 1, inherited_operatingsystem_id: 23 }],
+        { name: 'test', path: '/templates/1' }
+      )
+    );
 
-    expect(wrapper.text()).toMatch(/Host group OS/);
-    expect(wrapper.text()).toMatch(/Initial configuration template/);
+    expect(screen.getByText(/Host group OS: RHEL 8/)).toBeInTheDocument();
+    expect(screen.getByText(/Initial configuration template/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'test' })).toHaveAttribute(
+      'href',
+      '/templates/1'
+    );
   });
 
   it('for host group with OS without template', () => {
-    const wrapper = render(osHelperText(null, [{id: 23}], 1, [{ id: 1, inherited_operatingsystem_id: 23 }], {}));
+    render(
+      osHelperText(
+        null,
+        [{ id: 23, title: 'RHEL 8' }],
+        1,
+        [{ id: 1, inherited_operatingsystem_id: 23 }],
+        { os_path: '/operatingsystems/23' }
+      )
+    );
 
-    expect(wrapper.text()).toMatch(/Host group OS/);
-    expect(wrapper.text()).toMatch(/does not have assigned host_init_config template/);
+    expect(screen.getByText(/Host group OS: RHEL 8/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/does not have assigned host_init_config template/)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Operating system' })).toHaveAttribute(
+      'href',
+      '/operatingsystems/23'
+    );
   });
 
   it('for host group without OS', () => {
-    const wrapper = render(osHelperText(null, [], 1, [{ id: 1, inherited_operatingsystem_id: 23 }], {}));
-    expect(wrapper.text()).toMatch(/No OS from host group/);
+    render(
+      osHelperText(
+        null,
+        [],
+        1,
+        [{ id: 1, inherited_operatingsystem_id: 23 }],
+        {}
+      )
+    );
+
+    expect(screen.getByText('No OS from host group')).toBeInTheDocument();
   });
 
   it('no OS or host group', () => {


### PR DESCRIPTION
Fixes #39688 - replace enzyme tests with RTL for RegistrationCommandsPage helpers