### PR TITLE
refs #39594 - Skip eager load when schema is missing

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -15,7 +15,13 @@ class Permission < ApplicationRecord
     # We don't run seeds.rb initializer in test environment, so at the first call of this method in TemplateInputsController
     # during code loading @all_resources will be an empty array, and don't get populated with the actual resources from db later
     # In dev and prod environments, the seeds.rb initializer is run, so @all_resources will be populated with the actual resources
-    @all_resources = Permission.distinct.order(:resource_type).pluck(:resource_type).compact if @all_resources.empty?
+    if @all_resources.empty?
+      @all_resources = if table_exists?
+                         distinct.order(:resource_type).pluck(:resource_type).compact
+                       else
+                         []
+                       end
+    end
     @all_resources
   end
 

--- a/app/services/graphql_attribute.rb
+++ b/app/services/graphql_attribute.rb
@@ -11,6 +11,7 @@ class GraphqlAttribute
 
   def required?(attribute)
     return false unless resource_class
+    return false unless resource_class.respond_to?(:table_exists?) && resource_class.table_exists?
 
     return true if resource_class.columns_hash[attribute.to_s]&.null == false
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -366,6 +366,24 @@ module Foreman
       end
     end
 
+    # Spring preloads config/environment.rb with eager_load=true before rake can set
+    # config.eager_load = config.rake_eager_load (false). That loads controllers and
+    # GraphQL types which query the schema at class definition time. Skip eager load
+    # until migrations have run so bin/rake -T, db:create, and db:migrate can boot.
+    initializer(:skip_eager_load_without_schema, :before => :eager_load!) do |app|
+      next unless app.config.eager_load
+
+      schema_ready = begin
+        !Foreman.pending_migrations?
+      rescue ActiveRecord::ActiveRecordError
+        false
+      end
+      next if schema_ready
+
+      Rails.logger.warn("Database schema is not ready, skipping eager load")
+      app.config.eager_load = false
+    end
+
     config.after_initialize do
       require 'fog_extensions'
 

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -5,6 +5,14 @@ class PermissionTest < ActiveSupport::TestCase
     Permission.resources.each { |r| assert_kind_of String, r }
   end
 
+  test ".resources does not query the database when the table is missing" do
+    Permission.reset_resources
+    Permission.stubs(:table_exists?).returns(false)
+    assert_empty Permission.resources
+  ensure
+    Permission.reset_resources
+  end
+
   test ".resources works even for undefined resource types" do
     FactoryBot.create :permission, :resource_type => 'SomethingNotExisting'
     Permission.resources.each { |r| assert_not_nil r }

--- a/test/unit/grqphal_attribute_test.rb
+++ b/test/unit/grqphal_attribute_test.rb
@@ -12,5 +12,10 @@ class GraphqlAttributeTest < ActiveSupport::TestCase
     it 'detects than an attribute is optional' do
       assert_equal false, graphql_attribute.required?(:description)
     end
+
+    it 'does not load columns when the table is missing' do
+      resource_class.stubs(:table_exists?).returns(false)
+      assert_equal false, graphql_attribute.required?(:name)
+    end
   end
 end


### PR DESCRIPTION
Spring preloads the full Rails environment with eager_load enabled before rake can turn it off. Controllers and GraphQL types then query tables that do not exist yet, so bin/rake -T fails on a fresh database.

Skip eager load until migrations have run, and avoid schema lookups in Permission.resources and GraphqlAttribute when the table is missing.

**Note**: Github Actions are still running the `bundle exec` command, this will be updated as well.

#### How to test

Remove tables
```
psql -h 127.0.0.1 -p 5432 -U postgres
DROP database <dev_db>;
DROP database <test_db>;
```

run `bin/rake -T` or `bin/rails -T`



refs 1646c2e7a49905b1c6817c5525938aad7b7b958a


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
