### PR TITLE
Fixes #39702 - Drop Smart Proxy version mismatch check

### DIFF
--- a/app/assets/javascripts/proxy_status.js
+++ b/app/assets/javascripts/proxy_status.js
@@ -17,11 +17,7 @@ $(document).on('ContentLoad', function() {
 $(window).on('hashchange', tfm.tools.setTab); //so buttons that link to an anchor can open that tab
 
 function setItemStatus(item, response) {
-  if (response.success && response.message && response.message.warning) {
-    item.attr('title', response.message.warning.message);
-    item.addClass('text-warning');
-    item.html(tfm.tools.iconText('warning-triangle-o', '', 'pficon'));
-  } else if (response.success) {
+  if (response.success) {
     item.attr('title', __('Active'));
     item.addClass('text-success');
     item.html(tfm.tools.iconText('ok', '', 'pficon'));

--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -41,9 +41,7 @@ class SmartProxiesController < ApplicationController
 
   def ping
     requested_data do
-      versions_hash = @proxy_status[:version].version
-      versions_hash[:warning] = version_mismatch_warning(versions_hash) if versions_mismatched?(versions_hash)
-      versions_hash
+      @proxy_status[:version].version
     end
   end
 
@@ -145,35 +143,5 @@ class SmartProxiesController < ApplicationController
 
   def resource_base
     super.includes(:locations, :organizations)
-  end
-
-  def versions_mismatched?(proxy_versions_hash)
-    # we expect here the result of /versions proxy API call.
-    # It's structure is similar to: {:version => Proxy::VERSION, :modules => modules}.to_json
-    foreman_version = Foreman::Version.new
-    proxy_version = Foreman::Version.new(proxy_versions_hash['version'])
-
-    foreman_major = foreman_version.major.to_i
-    foreman_minor = foreman_version.minor.to_i
-
-    proxy_major = proxy_version.major.to_i
-    proxy_minor = proxy_version.minor.to_i
-
-    # foreman <-> proxy:
-    # 1.18.1 <-> 1.18.0 : OK
-    # 1.18.0 <-> 1.19.0 : OK
-    # 1.19.0 <-> 1.18.0 : Warn
-    # 1.18.0 <-> 1.20.0 : Warn
-    foreman_major != proxy_major ||
-      foreman_minor > proxy_minor ||
-      foreman_minor + 1 < proxy_minor
-  end
-
-  def version_mismatch_warning(proxy_versions_hash)
-    foreman_version = Foreman::Version.new.notag
-
-    {
-      :message => _('Core and proxy versions do not match. foreman: %{foreman_version}, foreman-proxy: %{proxy_version}') % {foreman_version: foreman_version, proxy_version: proxy_versions_hash['version']},
-    }
   end
 end

--- a/developer_docs/smart_proxy_dev_setup.asciidoc
+++ b/developer_docs/smart_proxy_dev_setup.asciidoc
@@ -123,6 +123,67 @@ grep ^:https_port config/settings.yml
 
 Then you can add Smart Proxy in Foreman UI as `https://localhost:8443`.
 
+[[compatibility-checks]]
+== Checking Smart Proxy compatibility
+
+Do not compare Foreman and Smart Proxy version numbers to decide whether a proxy can be used.
+`GET /version` is for display only (the Version field on the Smart Proxy page, the API, and About/status).
+A proxy plugin may report a backend version that is unrelated to Foreman, for example a Pulp Smart Proxy reporting Pulpcore `3.28.x` while Foreman is `3.x`.
+
+Compatibility is capability-based: ask whether the proxy advertises the feature or operation you need.
+
+=== Features vs capabilities
+
+* A *feature* is a running Smart Proxy module, such as TFTP, DHCP, BMC, or Pulp.
+* A *capability* is an optional operation inside a feature, advertised when Foreman refreshes the proxy from `GET /v2/features`.
+
+Features and capabilities are imported on create/refresh and stored on `SmartProxyFeature`.
+For how Smart Proxy advertises them on `GET /v2/features`, including the plugin `capability` DSL, see https://theforeman.org/2019/04/smart-proxy-capabilities-explained.html[Foreman Proxy Registration Protocol v2 explained].
+
+=== Checking for a feature
+
+Use this when the question is "can this proxy provide this service at all?":
+
+[source, ruby]
+----
+if proxy.has_feature?('TFTP')
+  # use the TFTP API
+end
+
+SmartProxy.with_features('TFTP')
+----
+
+=== Checking for a capability
+
+Use this when a feature exists, but you need to know whether a specific operation is supported:
+
+[source, ruby]
+----
+if proxy.has_capability?(:BMC, :power_action_v2)
+  # use the newer reboot/reset API
+else
+  # fall back for proxies that do not advertise the capability
+end
+----
+
+`has_capability?` stringifies the capability name, so `:power_action_v2` and `'power_action_v2'` are equivalent.
+
+If a Foreman plugin needs a new operation, the matching Smart Proxy plugin must advertise a new capability.
+Do not infer support from a version string.
+
+=== Examples in Foreman core
+
+BMC picks the power API from a capability, not from the proxy version (`PowerManager::BMC#power_action_v2`):
+
+[source, ruby]
+----
+smart_proxy = host.smart_proxies.with_features(:BMC).first
+return false unless smart_proxy
+smart_proxy.has_capability?(:BMC, :power_action_v2)
+----
+
+DHCP and TFTP do the same for `dhcp_filename_hostname` and `bootloader_universe` in `Orchestration::DHCP`.
+
 [[troubleshooting]]
 == Troubleshooting
 

--- a/test/controllers/smart_proxies_controller_test.rb
+++ b/test/controllers/smart_proxies_controller_test.rb
@@ -116,84 +116,14 @@ class SmartProxiesControllerTest < ActionController::TestCase
     assert_match(/Exception message/, show_response['message'])
   end
 
-  test "smart proxy version mismatched" do
-    expected_response = {'version' => '1.11', 'modules' => {'dns' => '1.11'}}
+  test "ping does not warn on unrelated proxy version" do
+    expected_response = {'version' => '3.28.12', 'modules' => {'pulpcore' => '3.28.12'}}
     ProxyStatus::Version.any_instance.stubs(:version).returns(expected_response)
     get :ping, params: { :id => smart_proxies(:one).to_param }, session: set_session_user
     assert_response :success
     show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_match(/versions do not match/, show_response['message']['warning']['message'])
-  end
-
-  test "smart proxy version with different tags matched" do
-    expected_response = {'version' => "#{Foreman::Version.new.notag}-testtag", 'modules' => {'dns' => '1.11'}}
-    ProxyStatus::Version.any_instance.stubs(:version).returns(expected_response)
-    get :ping, params: { :id => smart_proxies(:one).to_param }, session: set_session_user
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal '3.28.12', show_response['message']['version']
     assert_nil show_response['message']['warning']
-  end
-
-  test "smart proxy version with different z matched" do
-    foreman_version = Foreman::Version.new
-    foreman_x, foreman_y, foreman_z = foreman_version.major.to_i, foreman_version.minor.to_i, foreman_version.build.to_i
-    expected_response = {'version' => "#{foreman_x}.#{foreman_y}.#{foreman_z + 1}", 'modules' => {'dns' => '1.11'}}
-    ProxyStatus::Version.any_instance.stubs(:version).returns(expected_response)
-    get :ping, params: { :id => smart_proxies(:one).to_param }, session: set_session_user
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_nil show_response['message']['warning']
-  end
-
-  test "smart proxy version with next y matched" do
-    foreman_version = Foreman::Version.new
-    foreman_x, foreman_y, foreman_z = foreman_version.major.to_i, foreman_version.minor.to_i, foreman_version.build.to_i
-    expected_response = {'version' => "#{foreman_x}.#{foreman_y + 1}.#{foreman_z}", 'modules' => {'dns' => '1.11'}}
-    ProxyStatus::Version.any_instance.stubs(:version).returns(expected_response)
-    get :ping, params: { :id => smart_proxies(:one).to_param }, session: set_session_user
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_nil show_response['message']['warning']
-  end
-
-  test "smart proxy version with previous y warns" do
-    foreman_version = Foreman::Version.new
-    foreman_x, foreman_y, foreman_z = foreman_version.major.to_i, foreman_version.minor.to_i, foreman_version.build.to_i
-
-    # fix for 1.25 => 2.0 rename
-    if foreman_y == 0
-      foreman_x -= 1
-      foreman_y = 25
-    end
-
-    expected_response = {'version' => "#{foreman_x}.#{foreman_y - 1}.#{foreman_z}", 'modules' => {'dns' => '1.11'}}
-    ProxyStatus::Version.any_instance.stubs(:version).returns(expected_response)
-    get :ping, params: { :id => smart_proxies(:one).to_param }, session: set_session_user
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_match(/versions do not match/, show_response['message']['warning']['message'])
-  end
-
-  test "smart proxy version with y + 2 warns" do
-    foreman_version = Foreman::Version.new
-    foreman_x, foreman_y, foreman_z = foreman_version.major.to_i, foreman_version.minor.to_i, foreman_version.build.to_i
-    expected_response = {'version' => "#{foreman_x}.#{foreman_y + 2}.#{foreman_z}", 'modules' => {'dns' => '1.11'}}
-    ProxyStatus::Version.any_instance.stubs(:version).returns(expected_response)
-    get :ping, params: { :id => smart_proxies(:one).to_param }, session: set_session_user
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_match(/versions do not match/, show_response['message']['warning']['message'])
-  end
-
-  test "smart proxy version with different x warns" do
-    foreman_version = Foreman::Version.new
-    foreman_x, foreman_y, foreman_z = foreman_version.major.to_i, foreman_version.minor.to_i, foreman_version.build.to_i
-    expected_response = {'version' => "#{foreman_x - 1}.#{foreman_y}.#{foreman_z}", 'modules' => {'dns' => '1.11'}}
-    ProxyStatus::Version.any_instance.stubs(:version).returns(expected_response)
-    get :ping, params: { :id => smart_proxies(:one).to_param }, session: set_session_user
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_match(/versions do not match/, show_response['message']['warning']['message'])
   end
 
   test '#show' do


### PR DESCRIPTION
## What are you changing?

Remove the Smart Proxy version compatibility check from Foreman.

The current check compares the Foreman and Smart Proxy versions and reports a warning when they do not match. This is no longer useful because Foreman supports n-1 and n-2 Smart Proxy versions, so a supported Smart Proxy does not need to have the same version as Foreman.

This also avoids false version mismatch warnings from the pulp-smart-proxy plugin, which reports the Pulpcore version as its Smart Proxy version.

For feature compatibility, Smart Proxy capabilities should be used instead of comparing version numbers.

## Why are you changing it?

The existing version check can report false warnings such as:

`Core and proxy versions do not match. foreman 5.0.0; foreman-proxy 3.105.12`

Version numbers are not a reliable way to determine API/feature compatibility.

## Testing

* Verify that a Smart Proxy with a different version from Foreman no longer reports a version mismatch warning.
* Verify that the Smart Proxy version information is still returned correctly.
* Verify existing Smart Proxy ping/status functionality.
* Verify capability checks can be used for feature compatibility where required.

## Documentation

Add developer documentation explaining that Smart Proxy capabilities should be used for compatibility checks instead of comparing Smart Proxy and Foreman versions.