### PR TITLE
Fixes #39718 - Fix NoMethodError when taxonamy passed to images API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -423,7 +423,7 @@ module Api
 
     def parent_resource_details
       parent_name, parent_class, parent_id = nil
-      params.select { |param| param.ends_with?('_id') }.each do |param, value|
+      params.select { |param| allowed_nested_id.include?(param.to_s) }.each do |param, value|
         parent_id = value
         parent_name = param.delete_suffix('_id')
         parent_class = resource_class_for(resource_name(parent_name))

--- a/app/controllers/api/v2/audits_controller.rb
+++ b/app/controllers/api/v2/audits_controller.rb
@@ -21,6 +21,10 @@ module Api
       def resource_base(*args)
         super(*args).taxed_and_untaxed
       end
+
+      def allowed_nested_id
+        %w(host_id)
+      end
     end
   end
 end

--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -202,6 +202,10 @@ module Api
 
       private
 
+      def allowed_nested_id
+        %w(location_id organization_id)
+      end
+
       def action_permission
         case params[:action]
           when 'clone', 'import'

--- a/app/controllers/api/v2/template_inputs_controller.rb
+++ b/app/controllers/api/v2/template_inputs_controller.rb
@@ -83,6 +83,10 @@ module Api
 
       private
 
+      def allowed_nested_id
+        %w(template_id)
+      end
+
       def normalize_options
         if params[:template_input][:options].is_a?(Array)
           params[:template_input][:options] = params[:template_input][:options].join("\n")

--- a/test/controllers/api/base_controller_subclass_test.rb
+++ b/test/controllers/api/base_controller_subclass_test.rb
@@ -39,6 +39,12 @@ class Api::TestableController < Api::V2::BaseController
       super
     end
   end
+
+  private
+
+  def allowed_nested_id
+    %w(host_id domain_id subnet_id foo_id role_id)
+  end
 end
 
 class Testable < ApplicationRecord
@@ -246,6 +252,7 @@ class Api::TestableControllerTest < ActionController::TestCase
 
     context 'resouce scoping' do
       setup do
+        @controller.stubs(:allowed_nested_id).returns(['domain_id', 'foo_id'])
         @foo = Foo.create
         @testable = Testable.create(:foo => @foo)
       end
@@ -259,6 +266,7 @@ class Api::TestableControllerTest < ActionController::TestCase
 
     context 'nested resource permissions' do
       setup do
+        @controller.stubs(:allowed_nested_id).returns(['domain_id', 'host_id', 'subnet_id'])
         @child_associacion = mock('child_associacion')
         @testable_scope1 = mock('testable_scope1')
         @testable_scope2 = mock('testable_scope2')

--- a/test/controllers/api/v2/images_controller_test.rb
+++ b/test/controllers/api/v2/images_controller_test.rb
@@ -47,4 +47,61 @@ class Api::V2::ImagesControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  test "should create image with organization_id parameter" do
+    organization = FactoryBot.create(:organization)
+    compute_resource = images(:two).compute_resource
+
+    # Associate the compute resource with the organization
+    compute_resource.organizations << organization
+
+    assert_difference('Image.count') do
+      post :create, params: {
+        :compute_resource_id => compute_resource.id,
+        :organization_id => organization.id,
+        :image => valid_attrs,
+      }
+    end
+
+    assert_response :created
+  end
+
+  test "should create image with location_id parameter" do
+    location = FactoryBot.create(:location)
+    compute_resource = images(:two).compute_resource
+
+    # Associate the compute resource with the location
+    compute_resource.locations << location
+
+    assert_difference('Image.count') do
+      post :create, params: {
+        :compute_resource_id => compute_resource.id,
+        :location_id => location.id,
+        :image => valid_attrs,
+      }
+    end
+
+    assert_response :created
+  end
+
+  test "should create image with both organization_id and location_id parameters" do
+    organization = FactoryBot.create(:organization)
+    location = FactoryBot.create(:location)
+    compute_resource = images(:two).compute_resource
+
+    # Associate the compute resource with both
+    compute_resource.organizations << organization
+    compute_resource.locations << location
+
+    assert_difference('Image.count') do
+      post :create, params: {
+        :compute_resource_id => compute_resource.id,
+        :organization_id => organization.id,
+        :location_id => location.id,
+        :image => valid_attrs,
+      }
+    end
+
+    assert_response :created
+  end
 end


### PR DESCRIPTION
**Problem**

When `organization_id` or `location_id` are passed as top-level parameters to the images API (e.g., via hammer compute-resource image create), they were incorrectly being used as the nested parent object instead of compute_resource_id, causing a NoMethodError:

NoMethodError: undefined method 'images' for #<Organization id: 1, name: "NAME"...>

This occurred because parent_resource_details in base_controller.rb was iterating over all parameters ending with _id, rather than only those explicitly allowed via allowed_nested_id.

**Root Cause**

In app/controllers/api/base_controller.rb, the parent_resource_details method was selecting all params ending with _id:

`params.select { |param| param.ends_with?('_id') }.each do |param, value|`

This meant that `organization_id` and `location_id` could be selected as the parent resource before compute_resource_id, leading to the controller trying to call .images on an Organization or Location object (which don't have that association).

**Solution**

Modified parent_resource_details to only consider parameters that are explicitly listed in the controller's `allowed_nested_id method`:

`params.select { |param| allowed_nested_id.include?(param.to_s) }.each do |param, value|`

This ensures that only valid nested resource IDs are used as parent objects.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
