### PR TITLE
Fixes #39712 - Add native OpenID Connect authentication

### DIFF
--- a/app/controllers/api/v2/auth_source_oidcs_controller.rb
+++ b/app/controllers/api/v2/auth_source_oidcs_controller.rb
@@ -1,0 +1,109 @@
+module Api
+  module V2
+    class AuthSourceOidcsController < V2::BaseController
+      include Foreman::Controller::Parameters::AuthSourceOidc
+
+      wrap_parameters AuthSourceOidc,
+        :include => auth_source_oidc_params_filter.accessible_attributes(parameter_filter_context)
+
+      before_action :find_resource, :only => %w[show update destroy test]
+
+      api :GET, '/auth_source_oidcs/', N_('List all OpenID Connect authentication sources')
+      api :GET, '/locations/:location_id/auth_source_oidcs/', N_('List OpenID Connect authentication sources per location')
+      api :GET, '/organizations/:organization_id/auth_source_oidcs/', N_('List OpenID Connect authentication sources per organization')
+      param_group :taxonomy_scope, ::Api::V2::BaseController
+      param_group :search_and_pagination, ::Api::V2::BaseController
+      add_scoped_search_description_for(AuthSourceOidc)
+
+      def index
+        @auth_source_oidcs = resource_scope_for_index
+      end
+
+      api :GET, '/auth_source_oidcs/:id/', N_('Show an OpenID Connect authentication source')
+      param :id, :identifier, :required => true
+
+      def show
+      end
+
+      def_param_group :auth_source_oidc do
+        param :auth_source_oidc, Hash, :required => true, :action_aware => true do
+          param :name, String, :required => true
+          param :oidc_issuer, String, :required => true
+          param :oidc_client_id, String, :required => true
+          param :oidc_client_secret, String
+          param :oidc_scopes, String
+          param :oidc_client_auth_method, AuthSourceOidc::CLIENT_AUTH_METHODS.keys
+          param :oidc_allowed_algorithms, String
+          param :oidc_authorization_endpoint, String
+          param :oidc_token_endpoint, String
+          param :oidc_userinfo_endpoint, String
+          param :oidc_jwks_uri, String
+          param :oidc_end_session_endpoint, String
+          param :oidc_login_claim, String
+          param :oidc_email_claim, String
+          param :oidc_firstname_claim, String
+          param :oidc_lastname_claim, String
+          param :oidc_groups_claim, String
+          param :oidc_enabled, :bool
+          param :oidc_use_discovery, :bool
+          param :oidc_use_pkce, :bool
+          param :oidc_link_verified_email, :bool
+          param :oidc_update_user_attributes, :bool
+          param :oidc_allow_api_bearer, :bool
+          param :oidc_api_audiences, String, :desc => N_('Dedicated access-token audiences, different from the browser client ID')
+          param :onthefly_register, :bool
+          param :usergroup_sync, :bool
+          param :cacert, String
+          param_group :taxonomies, ::Api::V2::BaseController
+        end
+      end
+
+      api :POST, '/auth_source_oidcs/', N_('Create an OpenID Connect authentication source')
+      param_group :auth_source_oidc, :as => :create
+
+      def create
+        @auth_source_oidc = AuthSourceOidc.new(auth_source_oidc_params)
+        process_response @auth_source_oidc.save
+      end
+
+      api :PUT, '/auth_source_oidcs/:id/', N_('Update an OpenID Connect authentication source')
+      param :id, String, :required => true
+      param_group :auth_source_oidc
+
+      def update
+        process_response @auth_source_oidc.update(auth_source_oidc_params)
+      end
+
+      api :PUT, '/auth_source_oidcs/:id/test/', N_('Test an OpenID Connect authentication source')
+      param :id, String, :required => true
+
+      def test
+        result = @auth_source_oidc.test_connection
+        render :test, :locals => { :success => true, :message => result[:message] }
+      rescue Foreman::Exception => exception
+        render :test, :locals => { :success => false, :message => exception.message }
+      end
+
+      api :DELETE, '/auth_source_oidcs/:id/', N_('Delete an OpenID Connect authentication source')
+      param :id, String, :required => true
+
+      def destroy
+        process_response @auth_source_oidc.destroy
+      end
+
+      private
+
+      def action_permission
+        params[:action] == 'test' ? 'edit' : super
+      end
+
+      def controller_permission
+        'authenticators'
+      end
+
+      def resource_scope(...)
+        super.merge(AuthSourceOidc.with_taxonomy_scope)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/external_usergroups_controller.rb
+++ b/app/controllers/api/v2/external_usergroups_controller.rb
@@ -12,6 +12,7 @@ module Api
 
       api :GET, '/usergroups/:usergroup_id/external_usergroups', N_('List all external user groups for user group')
       api :GET, '/auth_source_ldaps/:auth_source_ldap_id/external_usergroups', N_('List all external user groups for LDAP authentication source')
+      api :GET, '/auth_source_oidcs/:auth_source_oidc_id/external_usergroups', N_('List all external user groups for OpenID Connect authentication source')
       param :usergroup_id, String, :required => true, :desc => N_('ID or name of user group')
 
       def index
@@ -20,6 +21,7 @@ module Api
 
       api :GET, '/usergroups/:usergroup_id/external_usergroups/:id', N_('Show an external user group for user group')
       api :GET, '/auth_source_ldaps/:auth_source_ldap_id/external_usergroups/:id', N_('Show an external user group for LDAP authentication source')
+      api :GET, '/auth_source_oidcs/:auth_source_oidc_id/external_usergroups/:id', N_('Show an external user group for OpenID Connect authentication source')
       param :usergroup_id, String, :required => true, :desc => N_('ID or name of user group')
       param :id, String, :required => true, :desc => N_('ID or name of external user group')
 
@@ -79,7 +81,7 @@ module Api
       end
 
       def allowed_nested_id
-        %w(usergroup_id auth_source_ldap_id)
+        %w(usergroup_id auth_source_ldap_id auth_source_oidc_id)
       end
 
       def refresh_external_usergroup

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -17,12 +17,14 @@ module Api
 
       api :GET, "/users/", N_("List all users")
       api :GET, "/auth_source_ldaps/:auth_source_ldap_id/users", N_("List all users for LDAP authentication source")
+      api :GET, "/auth_source_oidcs/:auth_source_oidc_id/users", N_("List all users for OpenID Connect authentication source")
       api :GET, "/auth_source_externals/:auth_source_external_id/users", N_("List all users for external authentication source")
       api :GET, "/usergroups/:usergroup_id/users", N_("List all users for user group")
       api :GET, "/roles/:role_id/users", N_("List all users for role")
       api :GET, "/locations/:location_id/users", N_("List all users for location")
       api :GET, "/organizations/:organization_id/users", N_("List all users for organization")
       param :auth_source_ldap_id, String, :desc => N_("ID of LDAP authentication source")
+      param :auth_source_oidc_id, String, :desc => N_("ID of OpenID Connect authentication source")
       param :usergroup_id, String, :desc => N_("ID of user group")
       param :role_id, String, :desc => N_("ID of role")
       param_group :taxonomy_scope, ::Api::V2::BaseController
@@ -64,6 +66,12 @@ module Api
         param :mail_enabled, :bool, :desc => N_("Enable user's email")
         param_group :taxonomies, ::Api::V2::BaseController
         param :ui_compact_mode, :bool, :desc => N_("Use compact UI")
+        param :oidc_identities_attributes, Array, :desc => N_("OpenID Connect identities (array or indexed hash)") do
+          param :id, Integer, :desc => N_("Identity ID when updating an existing identity")
+          param :auth_source_id, Integer, :required => true, :desc => N_("OpenID Connect authentication source ID")
+          param :subject, String, :required => true, :desc => N_("Stable sub claim from the provider")
+          param :_destroy, :bool, :desc => N_("Unlink the identity")
+        end
       end
 
       def_param_group :user do
@@ -134,7 +142,7 @@ module Api
       end
 
       def allowed_nested_id
-        %w(auth_source_ldap_id role_id location_id organization_id usergroup_id)
+        %w(auth_source_ldap_id auth_source_oidc_id role_id location_id organization_id usergroup_id)
       end
 
       def parameter_filter_context

--- a/app/controllers/auth_source_oidcs_controller.rb
+++ b/app/controllers/auth_source_oidcs_controller.rb
@@ -1,0 +1,68 @@
+class AuthSourceOidcsController < ApplicationController
+  include Foreman::Controller::Parameters::AuthSourceOidc
+
+  before_action :find_resource, :only => [:edit, :update, :destroy]
+
+  def new
+    @auth_source_oidc = AuthSourceOidc.new
+  end
+
+  def create
+    @auth_source_oidc = AuthSourceOidc.new(auth_source_oidc_params)
+    if @auth_source_oidc.save
+      process_success :success_redirect => auth_sources_path
+    else
+      process_error
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @auth_source_oidc.update(auth_source_oidc_params)
+      process_success :success_redirect => auth_sources_path
+    else
+      process_error
+    end
+  end
+
+  def destroy
+    if @auth_source_oidc.destroy
+      process_success :success_redirect => auth_sources_path
+    else
+      process_error :redirect => auth_sources_path
+    end
+  end
+
+  def test_connection
+    auth_source = test_auth_source
+    render :json => auth_source.test_connection, :status => :ok
+  rescue Foreman::Exception => exception
+    Foreman::Logging.exception('Failed to connect to OpenID Connect provider', exception)
+    render :json => { :message => exception.message }, :status => :unprocessable_entity
+  end
+
+  private
+
+  def test_auth_source
+    existing = AuthSourceOidc.with_taxonomy_scope.find_by(:id => params.dig(:auth_source_oidc, :id))
+    attributes = auth_source_oidc_params
+    attributes = attributes.except(:oidc_client_secret) if attributes[:oidc_client_secret].blank?
+    (existing || AuthSourceOidc.new).tap { |auth_source| auth_source.assign_attributes(attributes) }
+  end
+
+  def controller_permission
+    'authenticators'
+  end
+
+  def action_permission
+    return super unless params[:action] == 'test_connection'
+
+    params.dig(:auth_source_oidc, :id).present? ? 'edit' : 'create'
+  end
+
+  def resource_scope(...)
+    super.merge(AuthSourceOidc.with_taxonomy_scope)
+  end
+end

--- a/app/controllers/auth_sources_controller.rb
+++ b/app/controllers/auth_sources_controller.rb
@@ -3,6 +3,7 @@ class AuthSourcesController < ApplicationController
     @auth_sources = AuthSource.except_hidden
     @users = User.except_hidden.includes(:auth_source)
     @auth_source_ldaps = resource_base_search_and_page
+    @auth_source_oidcs = AuthSourceOidc.with_taxonomy_scope.search_for(params[:search], :order => params[:order])
   end
 
   private

--- a/app/controllers/concerns/foreman/controller/parameters/auth_source_oidc.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/auth_source_oidc.rb
@@ -1,0 +1,44 @@
+module Foreman::Controller::Parameters::AuthSourceOidc
+  extend ActiveSupport::Concern
+  include Foreman::Controller::Parameters::Taxonomix
+
+  class_methods do
+    def auth_source_oidc_params_filter
+      Foreman::ParameterFilter.new(::AuthSourceOidc).tap do |filter|
+        filter.permit :name,
+          :oidc_issuer,
+          :oidc_client_id,
+          :oidc_client_secret,
+          :oidc_scopes,
+          :oidc_client_auth_method,
+          :oidc_allowed_algorithms,
+          :oidc_authorization_endpoint,
+          :oidc_token_endpoint,
+          :oidc_userinfo_endpoint,
+          :oidc_jwks_uri,
+          :oidc_end_session_endpoint,
+          :oidc_login_claim,
+          :oidc_email_claim,
+          :oidc_firstname_claim,
+          :oidc_lastname_claim,
+          :oidc_groups_claim,
+          :oidc_enabled,
+          :oidc_use_discovery,
+          :oidc_use_pkce,
+          :oidc_link_verified_email,
+          :oidc_update_user_attributes,
+          :oidc_allow_api_bearer,
+          :oidc_api_audiences,
+          :onthefly_register,
+          :usergroup_sync,
+          :cacert
+
+        add_taxonomix_params_filter(filter)
+      end
+    end
+  end
+
+  def auth_source_oidc_params
+    self.class.auth_source_oidc_params_filter.filter_params(params, parameter_filter_context)
+  end
+end

--- a/app/controllers/concerns/foreman/controller/parameters/user.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/user.rb
@@ -28,6 +28,9 @@ module Foreman::Controller::Parameters::User
           if !ctx.editing_self? && (ctx.ui? || ctx.api?)
             ctx.permit :auth_source, :auth_source_id, :auth_source_name,
               :roles => [], :role_ids => [], :role_names => []
+            if ctx.has_edit_user_permissions?
+              ctx.permit :oidc_identities_attributes => [:id, :auth_source_id, :subject, :_destroy]
+            end
           end
         end
         add_taxonomix_params_filter(filter)

--- a/app/controllers/oidc_authentications_controller.rb
+++ b/app/controllers/oidc_authentications_controller.rb
@@ -1,0 +1,184 @@
+class OidcAuthenticationsController < ApplicationController
+  include Foreman::TelemetryHelper
+
+  FLOW_TTL = Oidc::AuthorizationRequest::STATE_TTL
+  MAX_CONCURRENT_FLOWS = 5
+
+  skip_before_action :require_login, :check_user_enabled, :authorize, :session_expiry,
+    :update_activity_time, :set_taxonomy, :require_mail, :check_empty_taxonomy,
+    :set_gettext_locale_db, :only => [:start, :callback]
+  after_action :update_activity_time, :only => :callback
+
+  def start
+    if (user = User.unscoped.enabled.find_by(:id => session[:user]))
+      inline_warning _('You are already logged in. Use account linking to connect another provider.')
+      redirect_to edit_user_path(:id => user)
+      return
+    end
+    session.delete(:user)
+
+    auth_source = find_oidc_auth_source
+    authorization = Oidc::AuthorizationRequest.new(auth_source, callback_url)
+    remember_flow(authorization.session_data)
+    redirect_to authorization.url, :allow_other_host => true
+  rescue ActiveRecord::RecordNotFound
+    authentication_failed(_('The selected OpenID Connect provider is not available'))
+  rescue Oidc::Error => exception
+    authentication_failed(exception.message, exception)
+  end
+
+  def link
+    auth_source = find_oidc_auth_source
+    authorization = Oidc::AuthorizationRequest.new(auth_source, callback_url)
+    flow = authorization.session_data.merge('link_user_id' => User.current.id)
+    remember_flow(flow)
+    redirect_to authorization.url, :allow_other_host => true
+  rescue ActiveRecord::RecordNotFound
+    authentication_failed(_('The selected OpenID Connect provider is not available'))
+  rescue Oidc::Error => exception
+    authentication_failed(exception.message, exception)
+  end
+
+  def callback
+    flow = consume_flow(params[:state])
+    validate_flow(flow)
+    raise Oidc::AuthenticationError, provider_error if params[:error].present?
+
+    auth_source = AuthSourceOidc.enabled.find(flow.fetch('auth_source_id'))
+    validate_linking_session(flow)
+    authentication = Oidc::Authenticator.new(auth_source, callback_url).authenticate(
+      params.require(:code), flow.fetch('nonce'), flow['code_verifier']
+    )
+    if flow['link_user_id']
+      link_identity(auth_source, authentication, flow['link_user_id'])
+      return
+    end
+
+    result = Oidc::UserResolver.new(auth_source, authentication).resolve
+    raise Oidc::AuthenticationError, _('User account is disabled') if result.user.disabled?
+
+    auth_source.sync_usergroups(result.user, authentication.groups)
+    complete_login(result.user, auth_source)
+  rescue ActionController::ParameterMissing, KeyError, ActiveRecord::RecordNotFound => exception
+    authentication_failed(_('The OpenID Connect authentication response is incomplete'), exception)
+  rescue Oidc::Error => exception
+    authentication_failed(exception.message, exception)
+  end
+
+  private
+
+  def callback_url
+    foreman_url(callback_oidc_authentications_path)
+  end
+
+  def find_oidc_auth_source
+    resource_finder(AuthSourceOidc.enabled, params[:id])
+  end
+
+  def foreman_url(path)
+    "#{Setting[:foreman_url].to_s.delete_suffix('/')}#{path}"
+  end
+
+  def remember_flow(flow)
+    flows = active_flows
+    flows[flow.fetch('state')] = flow
+    session[:oidc_authentications] = flows.sort_by { |_state, data| data.fetch('created_at') }.last(MAX_CONCURRENT_FLOWS).to_h
+  end
+
+  def consume_flow(state)
+    flows = active_flows
+    flow = flows.delete(state.to_s)
+    session[:oidc_authentications] = flows
+    flow
+  end
+
+  def active_flows
+    cutoff = FLOW_TTL.ago.to_i
+    session.to_hash.fetch('oidc_authentications', {}).select do |_state, flow|
+      flow.is_a?(Hash) && flow['created_at'].to_i >= cutoff
+    end
+  end
+
+  def validate_flow(flow)
+    raise Oidc::AuthenticationError, _('The OpenID Connect authentication state is invalid or expired') unless flow
+  end
+
+  def provider_error
+    _('The OpenID Connect provider rejected the authentication request (%s)') % params[:error].to_s.first(100)
+  end
+
+  def complete_login(user, auth_source)
+    original_uri = session[:original_uri]
+    backup_session_content([:organization_id, :location_id]) { reset_session }
+    session[:user] = user.id
+    session[:oidc_auth_source_id] = auth_source.id
+    store_default_taxonomy(user, 'organization') unless session.has_key?(:organization_id)
+    store_default_taxonomy(user, 'location') unless session.has_key?(:location_id)
+    user.post_successful_login
+    TopbarSweeper.expire_cache
+    telemetry_increment_counter(:successful_ui_logins)
+    Audit.manual_event!(
+      :action => 'login',
+      :auditable_type => 'User',
+      :auditable_id => user.id,
+      :auditable_name => user.to_label,
+      :actor => user,
+      :attribute => 'authentication',
+      :value => "User '#{user.login}' logged in with OIDC provider '#{auth_source.name}'",
+      :remote_address => request.remote_ip,
+      :request_uuid => request.uuid
+    )
+    logger.info "User '#{user.login}' logged in with OIDC provider '#{auth_source.name}' from '#{request.ip}'"
+    redirect_to(original_uri.presence || helpers.current_hosts_path)
+  end
+
+  def validate_linking_session(flow)
+    return unless flow['link_user_id']
+
+    user = User.unscoped.enabled.find_by(:id => session[:user])
+    if user&.id == flow['link_user_id'].to_i
+      User.current = user
+      return
+    end
+
+    raise Oidc::AuthenticationError, _('The account linking session is no longer valid')
+  end
+
+  def link_identity(auth_source, authentication, user_id)
+    user = User.unscoped.enabled.find(user_id)
+    Oidc::IdentityLinker.new(auth_source, authentication, user).link
+    auth_source.sync_usergroups(user, authentication.groups)
+    Audit.manual_event!(
+      :action => 'link',
+      :auditable_type => 'User',
+      :auditable_id => user.id,
+      :auditable_name => user.to_label,
+      :actor => user,
+      :attribute => 'authentication',
+      :value => "User '#{user.login}' linked OIDC provider '#{auth_source.name}'",
+      :remote_address => request.remote_ip,
+      :request_uuid => request.uuid
+    )
+    inline_success _('OpenID Connect identity linked successfully')
+    redirect_to edit_user_path(:id => user)
+  end
+
+  def authentication_failed(message, exception = nil)
+    Foreman::Logging.exception('OpenID Connect authentication failed', exception) if exception
+    linking_user = User.unscoped.enabled.find_by(:id => session[:user])
+    telemetry_increment_counter(:failed_ui_logins) unless linking_user
+    Audit.manual_event!(
+      :action => linking_user ? 'failed_link' : 'failed_login',
+      :auditable_type => 'User',
+      :auditable_id => linking_user&.id,
+      :auditable_name => linking_user&.to_label,
+      :actor => linking_user,
+      :attribute => 'authentication',
+      :value => linking_user ? 'OpenID Connect identity linking failed' : 'OpenID Connect login failed',
+      :remote_address => request.remote_ip,
+      :request_uuid => request.uuid
+    )
+    inline_error message
+    redirect_to(linking_user ? edit_user_path(:id => linking_user) : login_users_path)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -220,6 +220,7 @@ class UsersController < ApplicationController
 
     TopbarSweeper.expire_cache
     sso_logout_path = get_sso_method.try(:logout_url)
+    oidc_logout_path = oidc_logout_url
     user_id = session[:user]
     logged_out_user = User.unscoped.find_by_id(user_id)
     logged_out_user_login = logged_out_user.try(:login) || user_id
@@ -232,13 +233,15 @@ class UsersController < ApplicationController
       :auditable_id => user_id
     )
     session[:user] = @user = User.current = nil
+    session.delete(:oidc_auth_source_id)
+    session.delete(:oidc_authentications)
     if flash[:success] || flash[:info] || flash[:error]
       flash.keep
     else
       session.clear
       inline_success _("Logged out - See you soon")
     end
-    redirect_to(sso_logout_path || login_users_path, allow_other_host: true)
+    redirect_to(oidc_logout_path || sso_logout_path || login_users_path, allow_other_host: true)
   end
 
   def extlogout
@@ -262,6 +265,12 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def oidc_logout_url
+    auth_source = AuthSourceOidc.enabled.find_by(:id => session[:oidc_auth_source_id])
+    redirect_uri = "#{Setting[:foreman_url].to_s.delete_suffix('/')}#{login_users_path}"
+    Oidc::LogoutURL.new(auth_source, redirect_uri).to_s if auth_source
+  end
 
   def find_resource(permission = :view_users)
     editing_self? ? User.find(User.current.id) : User.authorized(permission).except_hidden.find(params[:id])

--- a/app/helpers/auth_sources_helper.rb
+++ b/app/helpers/auth_sources_helper.rb
@@ -1,5 +1,10 @@
 module AuthSourcesHelper
   def number_of_users_counter(users, auth_source_type)
+    if auth_source_type == 'AuthSourceOidc'
+      linked_user_ids = OidcIdentity.where(:auth_source_id => AuthSourceOidc.with_taxonomy_scope.select(:id)).distinct.pluck(:user_id).to_set
+      return users.count { |user| linked_user_ids.include?(user.id) }
+    end
+
     users.count { |user| user.auth_source.type == auth_source_type }
   end
 
@@ -17,6 +22,8 @@ module AuthSourcesHelper
       type = "Internal"
     when "AuthSourceExternal"
       type = "External"
+    when "AuthSourceOidc"
+      type = "OpenID Connect"
     end
     type
   end

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -5,6 +5,9 @@ module LoginHelper
       caption: Setting.replace_keywords(Setting[:login_text]),
       alerts: flash_inline,
       logoSrc: image_path("login_logo.png"),
+      oidcProviders: AuthSourceOidc.enabled.order(:name).map do |auth_source|
+        { name: auth_source.name, url: start_oidc_authentication_path(:id => auth_source) }
+      end,
     }
   end
 

--- a/app/models/auth_sources/auth_source_oidc.rb
+++ b/app/models/auth_sources/auth_source_oidc.rb
@@ -1,0 +1,159 @@
+class AuthSourceOidc < AuthSource
+  CLIENT_AUTH_METHODS = {
+    'client_secret_basic' => N_('HTTP Basic authentication'),
+    'client_secret_post' => N_('Request body authentication'),
+    'none' => N_('Public client'),
+  }.freeze
+  SUPPORTED_ALGORITHMS = %w[RS256 RS384 RS512 PS256 PS384 PS512 ES256 ES384 ES512].freeze
+
+  extend FriendlyId
+  friendly_id :name
+  include Parameterizable::ByIdName
+  include Encryptable
+  include Taxonomix
+  include NormalizeCacert
+
+  encrypts :oidc_client_secret
+
+  has_many :oidc_identities, :dependent => :restrict_with_error, :foreign_key => :auth_source_id, :inverse_of => :auth_source
+  has_many :linked_users, :through => :oidc_identities, :source => :user
+
+  before_destroy EnsureNotUsedBy.new(:oidc_identities), :prepend => true
+
+  validates :oidc_issuer, :oidc_client_id, :presence => true
+  validates :oidc_issuer, :url_schema => ['https']
+  validates :oidc_authorization_endpoint, :oidc_token_endpoint, :oidc_userinfo_endpoint,
+    :oidc_jwks_uri, :oidc_end_session_endpoint, :url_schema => ['https'], :allow_blank => true
+  validates :oidc_client_auth_method, :inclusion => { :in => CLIENT_AUTH_METHODS.keys }
+  validates :oidc_scopes, :presence => true
+  validates :oidc_allowed_algorithms, :presence => true
+  validates :cacert, :cacert => true
+  validates :oidc_login_claim, :oidc_email_claim, :oidc_firstname_claim,
+    :oidc_lastname_claim, :oidc_groups_claim, :presence => true
+  validate :openid_scope_present
+  validate :issuer_identifier_valid
+  validate :manual_endpoints_present, :unless => :oidc_use_discovery?
+  validate :client_secret_present, :unless => :public_client?
+  validate :pkce_required_for_public_client
+  validate :supported_signing_algorithms
+  validate :api_audience_present, :if => :oidc_allow_api_bearer?
+
+  before_validation :clear_client_secret_for_public_client
+
+  after_commit :expire_metadata_cache
+
+  scope :enabled, -> { where(:oidc_enabled => true) }
+
+  def auth_method_name
+    'OIDC'
+  end
+
+  def metadata(force: false)
+    Oidc::ProviderMetadata.new(self).fetch(:force => force)
+  end
+
+  def test_connection
+    raise Oidc::ConfigurationError, errors.full_messages.to_sentence unless valid?
+
+    provider_metadata = metadata(:force => true)
+    Oidc::JwtVerifier.new(self).validate(:jwks_uri => provider_metadata.fetch('jwks_uri'), :force => true)
+    { :success => true, :message => _('OpenID Connect provider validation was successful.') }
+  rescue Oidc::Error => exception
+    raise Foreman::WrappedException.new(exception, N_('Unable to validate the OpenID Connect provider'))
+  end
+
+  def scopes
+    oidc_scopes.to_s.split(/\s+/).reject(&:blank?).uniq
+  end
+
+  def allowed_algorithms
+    oidc_allowed_algorithms.to_s.split(/[\s,]+/).reject(&:blank?).uniq
+  end
+
+  def api_audiences
+    oidc_api_audiences.to_s.split(/[\s,]+/).reject(&:blank?).uniq
+  end
+
+  def public_client?
+    oidc_client_auth_method == 'none'
+  end
+
+  def supports_refresh?
+    false
+  end
+
+  def sync_usergroups(user, external_names)
+    return unless usergroup_sync?
+
+    normalized_names = Array(external_names).filter_map do |name|
+      name.to_s.downcase.presence
+    end.uniq
+    group_name = ExternalUsergroup.arel_table[:name].lower
+    mapped_ids = external_usergroups.where(group_name.in(normalized_names)).pluck(:usergroup_id)
+    current_ids = user.usergroups.where(:id => external_usergroups.select(:usergroup_id)).pluck(:id)
+
+    User.as_anonymous_admin do
+      UsergroupMember.transaction do
+        user.usergroup_ids = (user.usergroup_ids - current_ids + mapped_ids).uniq
+        user.save!(:validate => false)
+      end
+    end
+  rescue ActiveRecord::ActiveRecordError => exception
+    raise Oidc::AuthenticationError, N_('Unable to synchronize OpenID Connect user groups'), exception.backtrace
+  end
+
+  private
+
+  def openid_scope_present
+    errors.add(:oidc_scopes, N_('must include the openid scope')) unless scopes.include?('openid')
+  end
+
+  def manual_endpoints_present
+    [:oidc_authorization_endpoint, :oidc_token_endpoint, :oidc_jwks_uri].each do |attribute|
+      errors.add(attribute, :blank) if public_send(attribute).blank?
+    end
+  end
+
+  def client_secret_present
+    errors.add(:oidc_client_secret, :blank) if oidc_client_secret.blank?
+  end
+
+  def pkce_required_for_public_client
+    errors.add(:oidc_use_pkce, N_('must be enabled for public clients')) if public_client? && !oidc_use_pkce?
+  end
+
+  def issuer_identifier_valid
+    uri = URI.parse(oidc_issuer.to_s)
+    return if uri.is_a?(URI::HTTPS) && uri.host.present? && uri.userinfo.nil? && uri.query.nil? && uri.fragment.nil?
+
+    errors.add(:oidc_issuer, N_('must be an HTTPS URL without credentials, query parameters, or a fragment'))
+  rescue URI::InvalidURIError
+    errors.add(:oidc_issuer, N_('is not a valid URL'))
+  end
+
+  def supported_signing_algorithms
+    unsupported = allowed_algorithms - SUPPORTED_ALGORITHMS
+    return if allowed_algorithms.present? && unsupported.empty?
+
+    errors.add(:oidc_allowed_algorithms, N_('must contain only supported asymmetric signing algorithms'))
+  end
+
+  def clear_client_secret_for_public_client
+    self.oidc_client_secret = nil if public_client?
+  end
+
+  def api_audience_present
+    if api_audiences.empty?
+      errors.add(:oidc_api_audiences, :blank)
+    elsif api_audiences.include?(oidc_client_id)
+      errors.add(:oidc_api_audiences, N_('must not include the browser client ID'))
+    end
+  end
+
+  def expire_metadata_cache
+    return unless id
+
+    Rails.cache.delete(Oidc::ProviderMetadata.cache_key(id))
+    Rails.cache.delete(Oidc::JwtVerifier.cache_key(id))
+  end
+end

--- a/app/models/oidc_identity.rb
+++ b/app/models/oidc_identity.rb
@@ -1,0 +1,14 @@
+class OidcIdentity < ApplicationRecord
+  SUBJECT_MAX_LENGTH = 255
+
+  audited
+
+  belongs_to :user, :inverse_of => :oidc_identities
+  belongs_to :auth_source, :class_name => 'AuthSourceOidc', :inverse_of => :oidc_identities
+
+  validates_lengths_from_database
+  validates :subject, :presence => true, :length => { :maximum => SUBJECT_MAX_LENGTH },
+    :uniqueness => { :scope => :auth_source_id }
+  validates :auth_source_id, :uniqueness => { :scope => :user_id }
+  validates :email, :email => true, :allow_blank => true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,12 +52,16 @@ class User < ApplicationRecord
   has_many :widgets, :dependent => :destroy
   has_many :ssh_keys, :dependent => :destroy
   has_many :personal_access_tokens, :dependent => :destroy
+  has_many :oidc_identities, :dependent => :destroy, :inverse_of => :user
+  has_many :oidc_auth_sources, :through => :oidc_identities, :source => :auth_source
   has_many :table_preferences, :dependent => :destroy, :inverse_of => :user
   has_many :user_mail_notifications, :dependent => :destroy, :inverse_of => :user
   has_many :mail_notifications, :through => :user_mail_notifications
   has_many :notification_recipients, :dependent => :delete_all
 
   accepts_nested_attributes_for :user_mail_notifications, :allow_destroy => true, :reject_if => :reject_empty_intervals
+  accepts_nested_attributes_for :oidc_identities, :allow_destroy => true,
+    :reject_if => proc { |attributes| attributes['subject'].blank? }
 
   attr_name :login
 
@@ -133,6 +137,11 @@ class User < ApplicationRecord
   scoped_search :relation => :cached_usergroups, :on => :name, :rename => :usergroup, :complete_value => true
   scoped_search :relation => :auth_source, :on => :type, :rename => :auth_source_type, :complete_value => true
   scoped_search :relation => :auth_source, :on => :name, :rename => :auth_source, :complete_value => true
+  scoped_search :relation => :oidc_auth_sources, :on => :name, :rename => :oidc_auth_source, :complete_value => true
+  scoped_search :relation => :oidc_auth_sources, :on => :id, :rename => :oidc_auth_source_id,
+    :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+  scoped_search :on => :has_oidc_identity, :ext_method => :search_by_oidc_identity,
+    :complete_value => { :true => true, :false => false }, :operators => ['= '], :only_explicit => true
 
   default_scope lambda {
     with_taxonomy_scope do
@@ -200,6 +209,12 @@ class User < ApplicationRecord
       :include    => :cached_usergroups,
       :conditions => sanitize_sql_for_conditions([conditions, value, value]),
     }
+  end
+
+  def self.search_by_oidc_identity(_key, _operator, value)
+    condition = arel_table[:id].in(OidcIdentity.select(:user_id).arel)
+    condition = Arel::Nodes::Not.new(condition) unless value == 'true'
+    { :conditions => condition.to_sql }
   end
 
   # NOTE: that if you assign user new usergroups which change the admin flag you must save

--- a/app/services/oidc/access_token_verifier.rb
+++ b/app/services/oidc/access_token_verifier.rb
@@ -1,0 +1,35 @@
+module Oidc
+  class AccessTokenVerifier
+    def initialize(auth_source)
+      @auth_source = auth_source
+      @jwt_verifier = Oidc::JwtVerifier.new(auth_source)
+    end
+
+    def verify(token)
+      payload = jwt_verifier.decode(token, :audience => auth_source.api_audiences)
+      %w[sub iss aud exp iat].each do |claim|
+        raise Oidc::AuthenticationError.new(N_('The access token is missing the %s claim'), claim) if payload[claim].blank?
+      end
+      unless payload['sub'].is_a?(String) && payload['sub'].bytesize <= OidcIdentity::SUBJECT_MAX_LENGTH
+        raise Oidc::AuthenticationError, N_('The access token subject is invalid')
+      end
+      audience = payload['aud']
+      unless audience.is_a?(String) || (audience.is_a?(Array) && audience.present? && audience.all? { |value| value.is_a?(String) })
+        raise Oidc::AuthenticationError, N_('The access token audience is invalid')
+      end
+      unless payload['exp'].is_a?(Numeric) && payload['iat'].is_a?(Numeric)
+        raise Oidc::AuthenticationError, N_('The access token timestamps are invalid')
+      end
+      if payload['iat'] > Time.now.utc.to_i + Oidc::JwtVerifier::CLOCK_SKEW
+        raise Oidc::AuthenticationError, N_('The access token was issued in the future')
+      end
+      payload
+    rescue JWT::DecodeError => exception
+      raise Oidc::AuthenticationError.new(N_('The OpenID Connect access token is invalid: %s'), exception.message)
+    end
+
+    private
+
+    attr_reader :auth_source, :jwt_verifier
+  end
+end

--- a/app/services/oidc/authenticator.rb
+++ b/app/services/oidc/authenticator.rb
@@ -1,0 +1,93 @@
+module Oidc
+  class Authenticator
+    Result = Struct.new(:claims, :subject, :email, :email_verified, :groups, :keyword_init => true)
+
+    def initialize(auth_source, redirect_uri)
+      @auth_source = auth_source
+      @redirect_uri = redirect_uri
+      @metadata = auth_source.metadata
+      @http_client = Oidc::HttpClient.new(auth_source)
+    end
+
+    def authenticate(code, nonce, code_verifier = nil)
+      token_response = exchange_code(code, code_verifier)
+      validate_token_type(token_response)
+      id_claims = Oidc::TokenVerifier.new(auth_source).verify(
+        token_response.fetch('id_token'), nonce, token_response['access_token']
+      )
+      claims = id_claims.merge(userinfo(token_response, id_claims['sub']))
+      reader = Oidc::ClaimReader.new(claims)
+      groups = reader.read(auth_source.oidc_groups_claim)
+      groups = case groups
+               when Array then groups
+               when String then [groups]
+               else []
+               end
+      email = reader.read(auth_source.oidc_email_claim)
+      email = nil unless email.is_a?(String)
+
+      Result.new(
+        :claims => claims,
+        :subject => id_claims['sub'],
+        :email => email,
+        :email_verified => claims['email_verified'] == true,
+        :groups => groups.select { |group| group.is_a?(String) && group.bytesize <= 255 }.first(1000)
+      )
+    rescue KeyError => exception
+      raise Oidc::AuthenticationError.new(N_('The token response is missing %s'), exception.key)
+    end
+
+    private
+
+    attr_reader :auth_source, :redirect_uri, :metadata, :http_client
+
+    def exchange_code(code, code_verifier)
+      payload = {
+        :grant_type => 'authorization_code',
+        :code => code,
+        :redirect_uri => redirect_uri,
+      }
+      payload[:code_verifier] = code_verifier if code_verifier.present?
+      headers = { :content_type => 'application/x-www-form-urlencoded' }
+
+      case auth_source.oidc_client_auth_method
+      when 'client_secret_basic'
+        credentials = [auth_source.oidc_client_id, auth_source.oidc_client_secret].map do |value|
+          URI.encode_www_form_component(value.to_s)
+        end.join(':')
+        headers[:authorization] = "Basic #{Base64.strict_encode64(credentials)}"
+      when 'client_secret_post'
+        payload[:client_id] = auth_source.oidc_client_id
+        payload[:client_secret] = auth_source.oidc_client_secret
+      when 'none'
+        payload[:client_id] = auth_source.oidc_client_id
+      end
+
+      http_client.post_form(metadata.fetch('token_endpoint'), payload, headers)
+    end
+
+    def validate_token_type(token_response)
+      return if token_response['access_token'].blank?
+      return if token_response['token_type'].to_s.casecmp('Bearer').zero?
+
+      raise Oidc::AuthenticationError, N_('The token response contains an unsupported token type')
+    end
+
+    def userinfo(token_response, subject)
+      endpoint = metadata['userinfo_endpoint']
+      access_token = token_response['access_token']
+      return {} if endpoint.blank? || access_token.blank?
+
+      claims = http_client.get_json(endpoint, :authorization => "Bearer #{access_token}")
+      unless secure_compare(claims['sub'], subject)
+        raise Oidc::AuthenticationError, N_('The UserInfo subject does not match the ID token')
+      end
+      claims.except('iss', 'aud', 'azp', 'exp', 'iat', 'nbf', 'nonce')
+    end
+
+    def secure_compare(left, right)
+      left.is_a?(String) && right.is_a?(String) && left.present? && right.present? &&
+        left.bytesize == right.bytesize && ActiveSupport::SecurityUtils.secure_compare(left, right)
+    end
+  end
+end

--- a/app/services/oidc/authorization_request.rb
+++ b/app/services/oidc/authorization_request.rb
@@ -1,0 +1,53 @@
+module Oidc
+  class AuthorizationRequest
+    STATE_TTL = 10.minutes
+
+    attr_reader :session_data, :url
+
+    def initialize(auth_source, redirect_uri)
+      @auth_source = auth_source
+      @redirect_uri = redirect_uri
+      @metadata = auth_source.metadata
+      build
+    end
+
+    private
+
+    attr_reader :auth_source, :redirect_uri, :metadata
+
+    def build
+      state = SecureRandom.urlsafe_base64(32)
+      nonce = SecureRandom.urlsafe_base64(32)
+      verifier = SecureRandom.urlsafe_base64(64)
+      parameters = {
+        :client_id => auth_source.oidc_client_id,
+        :redirect_uri => redirect_uri,
+        :response_type => 'code',
+        :scope => auth_source.scopes.join(' '),
+        :state => state,
+        :nonce => nonce,
+      }
+      if auth_source.oidc_use_pkce?
+        parameters[:code_challenge] = Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), :padding => false)
+        parameters[:code_challenge_method] = 'S256'
+      end
+
+      @session_data = {
+        'auth_source_id' => auth_source.id,
+        'state' => state,
+        'nonce' => nonce,
+        'code_verifier' => auth_source.oidc_use_pkce? ? verifier : nil,
+        'created_at' => Time.now.utc.to_i,
+      }.compact
+      @url = append_query(metadata.fetch('authorization_endpoint'), parameters)
+    end
+
+    def append_query(url, parameters)
+      uri = URI.parse(url)
+      reserved = parameters.keys.map(&:to_s)
+      existing = URI.decode_www_form(uri.query.to_s).reject { |key, _value| reserved.include?(key) }
+      uri.query = URI.encode_www_form(existing + parameters.to_a)
+      uri.to_s
+    end
+  end
+end

--- a/app/services/oidc/claim_reader.rb
+++ b/app/services/oidc/claim_reader.rb
@@ -1,0 +1,19 @@
+module Oidc
+  class ClaimReader
+    def initialize(claims)
+      @claims = claims
+    end
+
+    def read(path)
+      path.to_s.split('.').reduce(claims) do |value, component|
+        break nil unless value.is_a?(Hash)
+
+        value[component]
+      end
+    end
+
+    private
+
+    attr_reader :claims
+  end
+end

--- a/app/services/oidc/error.rb
+++ b/app/services/oidc/error.rb
@@ -1,0 +1,10 @@
+module Oidc
+  class Error < Foreman::Exception
+  end
+
+  class ConfigurationError < Error
+  end
+
+  class AuthenticationError < Error
+  end
+end

--- a/app/services/oidc/http_client.rb
+++ b/app/services/oidc/http_client.rb
@@ -1,0 +1,63 @@
+module Oidc
+  class HttpClient
+    MAX_RESPONSE_SIZE = 1.megabyte
+    TIMEOUT = 10
+
+    def initialize(auth_source)
+      @auth_source = auth_source
+    end
+
+    def get_json(url, headers = {})
+      request_json(:get, url, :headers => headers)
+    end
+
+    def post_form(url, payload, headers = {})
+      request_json(:post, url, :payload => payload, :headers => headers)
+    end
+
+    def validate_url!(url)
+      uri = URI.parse(url.to_s)
+      unless uri.is_a?(URI::HTTPS) && uri.host.present? && uri.userinfo.nil? && uri.fragment.nil?
+        raise Oidc::ConfigurationError, N_('OpenID Connect endpoints must be HTTPS URLs without credentials or fragments')
+      end
+      uri
+    rescue URI::InvalidURIError => exception
+      raise Oidc::ConfigurationError, N_('OpenID Connect endpoint is not a valid URL'), exception.backtrace
+    end
+
+    private
+
+    attr_reader :auth_source
+
+    def request_json(method, url, options = {})
+      uri = validate_url!(url)
+      request_options = {
+        :method => method,
+        :url => uri.to_s,
+        :headers => { :accept => :json }.merge(options.fetch(:headers, {})),
+        :max_redirects => 0,
+        :open_timeout => TIMEOUT,
+        :timeout => TIMEOUT,
+        :verify_ssl => OpenSSL::SSL::VERIFY_PEER,
+      }
+      request_options[:payload] = options[:payload] if options.key?(:payload)
+      store = Foreman::Util.ssl_cert_store(auth_source.cacert)
+      request_options[:ssl_cert_store] = store if store
+
+      response = RestClient::Request.execute(request_options)
+      raise Oidc::AuthenticationError, N_('OpenID Connect provider response is too large') if response.body.bytesize > MAX_RESPONSE_SIZE
+
+      parsed = JSON.parse(response.body)
+      raise Oidc::AuthenticationError, N_('OpenID Connect provider returned an invalid response') unless parsed.is_a?(Hash)
+
+      parsed
+    rescue JSON::ParserError => exception
+      raise Oidc::AuthenticationError, N_('OpenID Connect provider returned invalid JSON'), exception.backtrace
+    rescue RestClient::ExceptionWithResponse => exception
+      message = exception.response&.code ? "HTTP #{exception.response.code}" : exception.message
+      raise Oidc::AuthenticationError.new(N_('OpenID Connect request failed: %s'), message)
+    rescue RestClient::Exception, SocketError, SystemCallError, Timeout::Error => exception
+      raise Oidc::AuthenticationError.new(N_('OpenID Connect request failed: %s'), exception.message)
+    end
+  end
+end

--- a/app/services/oidc/identity_linker.rb
+++ b/app/services/oidc/identity_linker.rb
@@ -1,0 +1,39 @@
+module Oidc
+  class IdentityLinker
+    def initialize(auth_source, authentication, user)
+      @auth_source = auth_source
+      @authentication = authentication
+      @user = user
+    end
+
+    def link
+      identity = auth_source.oidc_identities.find_by(:subject => authentication.subject)
+      if identity && identity.user_id != user.id
+        raise Oidc::AuthenticationError, N_('This OpenID Connect identity is already linked to another account')
+      end
+
+      identity ||= auth_source.oidc_identities.find_or_initialize_by(:user => user)
+      identity.assign_attributes(
+        :subject => authentication.subject,
+        :email => authentication.email,
+        :email_verified => authentication.email_verified,
+        :last_login_on => Time.now.utc
+      )
+      identity.save!
+      identity
+    rescue ActiveRecord::RecordInvalid => exception
+      raise Oidc::AuthenticationError.new(
+        N_('Unable to link the OpenID Connect identity: %s'), exception.record.errors.full_messages.to_sentence
+      )
+    rescue ActiveRecord::RecordNotUnique => exception
+      raise Oidc::AuthenticationError, N_('The OpenID Connect identity or provider is already linked'), exception.backtrace if @retried
+
+      @retried = true
+      retry
+    end
+
+    private
+
+    attr_reader :auth_source, :authentication, :user
+  end
+end

--- a/app/services/oidc/jwt_verifier.rb
+++ b/app/services/oidc/jwt_verifier.rb
@@ -1,0 +1,81 @@
+module Oidc
+  class JwtVerifier
+    CLOCK_SKEW = 60
+    JWKS_CACHE_TTL = 1.hour
+
+    def self.cache_key(auth_source_id)
+      "oidc/jwks/#{auth_source_id}"
+    end
+
+    def initialize(auth_source)
+      @auth_source = auth_source
+      @http_client = Oidc::HttpClient.new(auth_source)
+    end
+
+    def decode(token, audience:)
+      JWT.decode(token, nil, true,
+        :algorithms => auth_source.allowed_algorithms,
+        :aud => audience,
+        :verify_aud => true,
+        :iss => auth_source.oidc_issuer,
+        :verify_iss => true,
+        :leeway => CLOCK_SKEW,
+        &key_finder)
+        .first
+    rescue JWT::VerificationError
+      raise if @signature_retry
+
+      @signature_retry = true
+      Rails.cache.delete(jwks_cache_key)
+      retry
+    end
+
+    def validate(jwks_uri: nil, force: false)
+      Rails.cache.delete(jwks_cache_key) if force && auth_source.persisted?
+      keys = jwks_uri ? load_jwks(jwks_uri) : jwks
+      Rails.cache.write(jwks_cache_key, keys, :expires_in => JWKS_CACHE_TTL) if jwks_uri && auth_source.persisted?
+      true
+    end
+
+    private
+
+    attr_reader :auth_source, :http_client
+
+    def key_finder
+      lambda do |header|
+        find_key(header)
+      rescue JWT::DecodeError
+        raise if @key_lookup_retry
+
+        @key_lookup_retry = true
+        Rails.cache.delete(jwks_cache_key)
+        find_key(header)
+      end
+    end
+
+    def find_key(header)
+      finder = JWT::JWK::KeyFinder.new(:jwks => jwks)
+      key = finder.key_for(header['kid']) if header['kid'].present?
+      key ||= finder.key_for(header['x5t']) if header['x5t'].present?
+      key
+    end
+
+    def jwks
+      return load_jwks if auth_source.new_record?
+
+      Rails.cache.fetch(jwks_cache_key, :expires_in => JWKS_CACHE_TTL) { load_jwks }
+    end
+
+    def load_jwks(jwks_uri = nil)
+      response = http_client.get_json(jwks_uri || auth_source.metadata.fetch('jwks_uri'))
+      keys = response['keys']
+      raise Oidc::AuthenticationError, N_('The provider returned an invalid JSON Web Key Set') unless keys.is_a?(Array) && keys.present?
+
+      { :keys => keys.map(&:symbolize_keys) }
+    end
+
+    def jwks_cache_key
+      self.class.cache_key(auth_source.id)
+    end
+  end
+end

--- a/app/services/oidc/logout_url.rb
+++ b/app/services/oidc/logout_url.rb
@@ -1,0 +1,30 @@
+module Oidc
+  class LogoutURL
+    def initialize(auth_source, redirect_uri)
+      @auth_source = auth_source
+      @redirect_uri = redirect_uri
+    end
+
+    def to_s
+      endpoint = auth_source.metadata['end_session_endpoint']
+      return if endpoint.blank?
+
+      uri = URI.parse(endpoint)
+      parameters = {
+        :client_id => auth_source.oidc_client_id,
+        :post_logout_redirect_uri => redirect_uri,
+      }
+      reserved = parameters.keys.map(&:to_s)
+      existing = URI.decode_www_form(uri.query.to_s).reject { |key, _value| reserved.include?(key) }
+      uri.query = URI.encode_www_form(existing + parameters.to_a)
+      uri.to_s
+    rescue Oidc::Error, URI::InvalidURIError => exception
+      Foreman::Logging.exception('Unable to build the OpenID Connect logout URL', exception)
+      nil
+    end
+
+    private
+
+    attr_reader :auth_source, :redirect_uri
+  end
+end

--- a/app/services/oidc/provider_metadata.rb
+++ b/app/services/oidc/provider_metadata.rb
@@ -1,0 +1,85 @@
+module Oidc
+  class ProviderMetadata
+    REQUIRED_ENDPOINTS = %w[authorization_endpoint token_endpoint jwks_uri].freeze
+    OPTIONAL_ENDPOINTS = %w[userinfo_endpoint end_session_endpoint].freeze
+    CACHE_TTL = 1.hour
+
+    def self.cache_key(auth_source_id)
+      "oidc/provider_metadata/#{auth_source_id}"
+    end
+
+    def initialize(auth_source)
+      @auth_source = auth_source
+      @http_client = Oidc::HttpClient.new(auth_source)
+    end
+
+    def fetch(force: false)
+      return validate(manual_metadata) unless auth_source.oidc_use_discovery?
+      return discover if auth_source.new_record? || force
+
+      Rails.cache.fetch(self.class.cache_key(auth_source.id), :expires_in => CACHE_TTL, :force => force) do
+        discover
+      end
+    end
+
+    private
+
+    attr_reader :auth_source, :http_client
+
+    def discover
+      issuer = auth_source.oidc_issuer.delete_suffix('/')
+      metadata = http_client.get_json("#{issuer}/.well-known/openid-configuration")
+      unless secure_compare(metadata['issuer'], auth_source.oidc_issuer)
+        raise Oidc::ConfigurationError, N_('Discovered issuer does not match the configured issuer')
+      end
+
+      validate(metadata)
+    end
+
+    def manual_metadata
+      {
+        'issuer' => auth_source.oidc_issuer,
+        'authorization_endpoint' => auth_source.oidc_authorization_endpoint,
+        'token_endpoint' => auth_source.oidc_token_endpoint,
+        'userinfo_endpoint' => auth_source.oidc_userinfo_endpoint,
+        'jwks_uri' => auth_source.oidc_jwks_uri,
+        'end_session_endpoint' => auth_source.oidc_end_session_endpoint,
+      }.compact
+    end
+
+    def validate(metadata)
+      REQUIRED_ENDPOINTS.each do |endpoint|
+        raise Oidc::ConfigurationError.new(N_('Provider metadata is missing %s'), endpoint) if metadata[endpoint].blank?
+        http_client.validate_url!(metadata[endpoint])
+      end
+      OPTIONAL_ENDPOINTS.each do |endpoint|
+        http_client.validate_url!(metadata[endpoint]) if metadata[endpoint].present?
+      end
+      challenge_methods = metadata['code_challenge_methods_supported']
+      if auth_source.oidc_use_pkce? && challenge_methods.present? && (!challenge_methods.is_a?(Array) || !challenge_methods.include?('S256'))
+        raise Oidc::ConfigurationError, N_('The provider does not support the configured PKCE S256 method')
+      end
+      response_types = metadata['response_types_supported']
+      if response_types.present? && (!response_types.is_a?(Array) || !response_types.include?('code'))
+        raise Oidc::ConfigurationError, N_('The provider does not support the authorization code flow')
+      end
+      methods = metadata['token_endpoint_auth_methods_supported']
+      if !auth_source.public_client? && methods.present? && (!methods.is_a?(Array) || !methods.include?(auth_source.oidc_client_auth_method))
+        raise Oidc::ConfigurationError, N_('The provider does not support the configured client authentication method')
+      end
+      signing_algorithms = metadata['id_token_signing_alg_values_supported']
+      if signing_algorithms.present? && (!signing_algorithms.is_a?(Array) || (auth_source.allowed_algorithms & signing_algorithms).empty?)
+        raise Oidc::ConfigurationError, N_('The provider does not support any configured ID token signing algorithm')
+      end
+
+      metadata.slice('issuer', 'authorization_endpoint', 'token_endpoint', 'userinfo_endpoint',
+        'jwks_uri', 'end_session_endpoint', 'code_challenge_methods_supported',
+        'token_endpoint_auth_methods_supported', 'id_token_signing_alg_values_supported')
+    end
+
+    def secure_compare(left, right)
+      left.is_a?(String) && right.is_a?(String) && left.present? && right.present? &&
+        left.bytesize == right.bytesize && ActiveSupport::SecurityUtils.secure_compare(left, right)
+    end
+  end
+end

--- a/app/services/oidc/token_verifier.rb
+++ b/app/services/oidc/token_verifier.rb
@@ -1,0 +1,88 @@
+module Oidc
+  class TokenVerifier
+    CLOCK_SKEW = 60
+
+    def initialize(auth_source)
+      @auth_source = auth_source
+      @jwt_verifier = Oidc::JwtVerifier.new(auth_source)
+    end
+
+    def verify(id_token, nonce, access_token = nil)
+      payload = decode(id_token)
+      validate_required_claims(payload)
+      validate_authorized_party(payload)
+      validate_nonce(payload, nonce)
+      validate_access_token_hash(payload, id_token, access_token)
+      payload
+    rescue JWT::DecodeError => exception
+      raise Oidc::AuthenticationError.new(N_('The OpenID Connect ID token is invalid: %s'), exception.message)
+    end
+
+    private
+
+    attr_reader :auth_source, :jwt_verifier
+
+    def decode(id_token)
+      jwt_verifier.decode(id_token, :audience => auth_source.oidc_client_id)
+    end
+
+    def validate_required_claims(payload)
+      %w[sub iss aud exp iat].each do |claim|
+        raise Oidc::AuthenticationError.new(N_('The ID token is missing the %s claim'), claim) if payload[claim].blank?
+      end
+      unless payload['sub'].is_a?(String) && payload['sub'].bytesize <= OidcIdentity::SUBJECT_MAX_LENGTH
+        raise Oidc::AuthenticationError, N_('The ID token subject is invalid')
+      end
+      unless valid_audience?(payload['aud'])
+        raise Oidc::AuthenticationError, N_('The ID token audience is invalid')
+      end
+      unless payload['exp'].is_a?(Numeric) && payload['iat'].is_a?(Numeric)
+        raise Oidc::AuthenticationError, N_('The ID token timestamps are invalid')
+      end
+      if payload['iat'] > Time.now.utc.to_i + CLOCK_SKEW
+        raise Oidc::AuthenticationError, N_('The ID token was issued in the future')
+      end
+    end
+
+    def validate_authorized_party(payload)
+      audiences = Array(payload['aud'])
+      return unless audiences.length > 1 || payload['azp'].present?
+      return if secure_compare(payload['azp'], auth_source.oidc_client_id)
+
+      raise Oidc::AuthenticationError, N_('The ID token authorized party is invalid')
+    end
+
+    def validate_nonce(payload, expected_nonce)
+      return if secure_compare(payload['nonce'], expected_nonce)
+
+      raise Oidc::AuthenticationError, N_('The ID token nonce is invalid')
+    end
+
+    def validate_access_token_hash(payload, id_token, access_token)
+      return if payload['at_hash'].blank?
+      raise Oidc::AuthenticationError, N_('The ID token contains at_hash without an access token') if access_token.blank?
+
+      algorithm = JWT.decode(id_token, nil, false).last.fetch('alg')
+      digest_bits = algorithm[/\d+\z/]
+      raise Oidc::AuthenticationError, N_('The ID token uses an unsupported hash algorithm') unless %w[256 384 512].include?(digest_bits)
+
+      digest_name = "SHA#{digest_bits}"
+      digest = OpenSSL::Digest.new(digest_name).digest(access_token)
+      expected = Base64.urlsafe_encode64(digest.first(digest.bytesize / 2), :padding => false)
+      return if secure_compare(payload['at_hash'], expected)
+
+      raise Oidc::AuthenticationError, N_('The ID token access token hash is invalid')
+    rescue KeyError, OpenSSL::Digest::DigestError
+      raise Oidc::AuthenticationError, N_('The ID token uses an unsupported hash algorithm')
+    end
+
+    def secure_compare(left, right)
+      left.is_a?(String) && right.is_a?(String) && left.present? && right.present? &&
+        left.bytesize == right.bytesize && ActiveSupport::SecurityUtils.secure_compare(left, right)
+    end
+
+    def valid_audience?(audience)
+      audience.is_a?(String) || (audience.is_a?(Array) && audience.present? && audience.all? { |value| value.is_a?(String) })
+    end
+  end
+end

--- a/app/services/oidc/user_resolver.rb
+++ b/app/services/oidc/user_resolver.rb
@@ -1,0 +1,124 @@
+module Oidc
+  class UserResolver
+    Result = Struct.new(:user, :identity, :created, :keyword_init => true)
+
+    def initialize(auth_source, authentication)
+      @auth_source = auth_source
+      @authentication = authentication
+      @claims = Oidc::ClaimReader.new(authentication.claims)
+    end
+
+    def resolve
+      identity = auth_source.oidc_identities.find_by(:subject => authentication.subject)
+      return update_identity(identity, identity_user(identity)) if identity
+
+      User.as_anonymous_admin do
+        User.transaction do
+          user = linked_user
+          created = user.nil?
+          user ||= provision_user
+          raise Oidc::AuthenticationError, N_('No Foreman account is linked to this identity') unless user
+
+          identity = auth_source.oidc_identities.create!(
+            :user => user,
+            :subject => authentication.subject,
+            :email => authentication.email,
+            :email_verified => authentication.email_verified,
+            :last_login_on => Time.now.utc
+          )
+          update_user(user) unless created
+          Result.new(:user => user, :identity => identity, :created => created)
+        end
+      end
+    rescue ActiveRecord::RecordInvalid => exception
+      raise Oidc::AuthenticationError.new(
+        N_('Unable to link the OpenID Connect identity: %s'), exception.record.errors.full_messages.to_sentence
+      )
+    rescue ActiveRecord::RecordNotUnique => exception
+      identity = auth_source.oidc_identities.find_by(:subject => authentication.subject)
+      return update_identity(identity, identity_user(identity)) if identity
+
+      raise Oidc::AuthenticationError, N_('The OpenID Connect identity or provider is already linked'), exception.backtrace
+    end
+
+    private
+
+    attr_reader :auth_source, :authentication, :claims
+
+    def update_identity(identity, user)
+      raise Oidc::AuthenticationError, N_('User account is disabled') if user.disabled?
+
+      User.as_anonymous_admin do
+        identity.update!(
+          :email => authentication.email,
+          :email_verified => authentication.email_verified,
+          :last_login_on => Time.now.utc
+        )
+        update_user(user)
+      end
+      Result.new(:user => user, :identity => identity, :created => false)
+    end
+
+    def identity_user(identity)
+      User.unscoped.except_hidden.find_by(:id => identity.user_id) ||
+        raise(Oidc::AuthenticationError, N_('No Foreman account is linked to this identity'))
+    end
+
+    def linked_user
+      return unless auth_source.oidc_link_verified_email? && authentication.email_verified && authentication.email.present?
+
+      users = User.unscoped.except_hidden.where('LOWER(mail) = ?', authentication.email.downcase).limit(2).to_a
+      if users.length > 1
+        raise Oidc::AuthenticationError, N_('More than one Foreman account uses the verified email address')
+      end
+      user = users.first
+      raise Oidc::AuthenticationError, N_('User account is disabled') if user&.disabled?
+
+      user
+    end
+
+    def provision_user
+      return unless auth_source.onthefly_register?
+
+      user = User.new(user_attributes.merge(:auth_source => auth_source))
+      user.locations = auth_source.locations
+      user.organizations = auth_source.organizations
+      user.save!
+      user
+    end
+
+    def update_user(user)
+      return unless auth_source.oidc_update_user_attributes?
+
+      attributes = user_attributes.except(:login).select { |_key, value| value.present? }
+      unless user.update(attributes)
+        Rails.logger.warn "Unable to update OIDC user #{user.login}: #{user.errors.full_messages.to_sentence}"
+      end
+    end
+
+    def user_attributes
+      {
+        :login => unique_login,
+        :mail => authentication.email,
+        :firstname => claim_string(auth_source.oidc_firstname_claim),
+        :lastname => claim_string(auth_source.oidc_lastname_claim),
+      }
+    end
+
+    def unique_login
+      requested = claim_string(auth_source.oidc_login_claim).to_s.presence || authentication.email.to_s.split('@').first.presence
+      requested ||= "oidc-#{Digest::SHA256.hexdigest(authentication.subject).first(12)}"
+      requested = requested.gsub(/[^[:alnum:]_\-@.\\$#+]/, '-').first(100)
+      requested = "oidc-#{Digest::SHA256.hexdigest(authentication.subject).first(12)}" unless requested.match?(/[[:alnum:]]/)
+      return requested unless User.unscoped.where(:lower_login => requested.downcase).exists?
+
+      suffix = "-#{Digest::SHA256.hexdigest("#{auth_source.id}:#{authentication.subject}").first(8)}"
+      "#{requested.first(100 - suffix.length)}#{suffix}"
+    end
+
+    def claim_string(path)
+      value = claims.read(path)
+      value if value.is_a?(String)
+    end
+  end
+end

--- a/app/services/sso.rb
+++ b/app/services/sso.rb
@@ -1,5 +1,5 @@
 module SSO
-  METHODS = [Apache, Basic, Jwt, Oauth, OpenidConnect]
+  METHODS = [Apache, Basic, Jwt, Oauth, ConfiguredOpenidConnect, OpenidConnect]
 
   def self.get_available(controller)
     all_methods = all.map { |method| method.new(controller) }

--- a/app/services/sso/configured_openid_connect.rb
+++ b/app/services/sso/configured_openid_connect.rb
@@ -1,0 +1,47 @@
+module SSO
+  class ConfiguredOpenidConnect < Base
+    attr_reader :current_user
+
+    def available?
+      return false unless controller.api_request? && bearer_token.present?
+
+      @auth_source = provider_for_token
+      @auth_source.present?
+    end
+
+    def authenticated?
+      payload = Oidc::AccessTokenVerifier.new(auth_source).verify(bearer_token)
+      identity = auth_source.oidc_identities.find_by(:subject => payload['sub'])
+      @current_user = User.unscoped.except_hidden.enabled.find_by(:id => identity&.user_id)
+      @current_user.present?
+    rescue Oidc::Error => exception
+      Foreman::Logging.exception('Configured OpenID Connect bearer authentication failed', exception)
+      false
+    end
+
+    private
+
+    attr_reader :auth_source
+
+    def provider_for_token
+      payload = JWT.decode(bearer_token, nil, false).first
+      issuer = payload['iss']
+      audiences = payload['aud'].is_a?(Array) ? payload['aud'] : [payload['aud']]
+      return unless issuer.is_a?(String) && audiences.present? && audiences.all? { |audience| audience.is_a?(String) }
+
+      matches = AuthSourceOidc.enabled.where(:oidc_allow_api_bearer => true, :oidc_issuer => issuer).select do |auth_source|
+        (auth_source.api_audiences & audiences).present?
+      end
+      matches.one? ? matches.first : nil
+    rescue JWT::DecodeError
+      nil
+    end
+
+    def bearer_token
+      return @bearer_token if defined?(@bearer_token)
+
+      scheme, token = request.authorization.to_s.split(/\s+/, 2)
+      @bearer_token = scheme&.casecmp('Bearer')&.zero? ? token.presence : nil
+    end
+  end
+end

--- a/app/views/api/v2/auth_source_oidcs/base.json.rabl
+++ b/app/views/api/v2/auth_source_oidcs/base.json.rabl
@@ -1,0 +1,3 @@
+object @auth_source_oidc
+
+attributes :id, :type, :name

--- a/app/views/api/v2/auth_source_oidcs/create.json.rabl
+++ b/app/views/api/v2/auth_source_oidcs/create.json.rabl
@@ -1,0 +1,3 @@
+object @auth_source_oidc
+
+extends 'api/v2/auth_source_oidcs/show'

--- a/app/views/api/v2/auth_source_oidcs/index.json.rabl
+++ b/app/views/api/v2/auth_source_oidcs/index.json.rabl
@@ -1,0 +1,7 @@
+collection @auth_source_oidcs
+
+extends 'api/v2/auth_source_oidcs/main'
+
+node do |auth_source_oidc|
+  partial('api/v2/taxonomies/children_nodes', :object => auth_source_oidc)
+end

--- a/app/views/api/v2/auth_source_oidcs/main.json.rabl
+++ b/app/views/api/v2/auth_source_oidcs/main.json.rabl
@@ -1,0 +1,12 @@
+object @auth_source_oidc
+
+extends 'api/v2/auth_source_oidcs/base'
+
+attributes :oidc_issuer, :oidc_client_id, :oidc_scopes, :oidc_client_auth_method,
+  :oidc_allowed_algorithms, :oidc_authorization_endpoint, :oidc_token_endpoint,
+  :oidc_userinfo_endpoint, :oidc_jwks_uri, :oidc_end_session_endpoint,
+  :oidc_login_claim, :oidc_email_claim, :oidc_firstname_claim, :oidc_lastname_claim,
+  :oidc_groups_claim, :oidc_enabled, :oidc_use_discovery, :oidc_use_pkce,
+  :oidc_link_verified_email, :oidc_update_user_attributes, :onthefly_register,
+  :oidc_allow_api_bearer, :oidc_api_audiences, :usergroup_sync, :cacert,
+  :created_at, :updated_at

--- a/app/views/api/v2/auth_source_oidcs/show.json.rabl
+++ b/app/views/api/v2/auth_source_oidcs/show.json.rabl
@@ -1,0 +1,7 @@
+object @auth_source_oidc
+
+extends 'api/v2/auth_source_oidcs/main'
+
+node do |auth_source_oidc|
+  partial('api/v2/taxonomies/children_nodes', :object => auth_source_oidc)
+end

--- a/app/views/api/v2/auth_source_oidcs/test.json.rabl
+++ b/app/views/api/v2/auth_source_oidcs/test.json.rabl
@@ -1,0 +1,11 @@
+object @auth_source_oidc
+
+extends 'api/v2/auth_source_oidcs/base'
+
+node :success do
+  locals[:success]
+end
+
+node :message do
+  locals[:message]
+end

--- a/app/views/api/v2/auth_source_oidcs/update.json.rabl
+++ b/app/views/api/v2/auth_source_oidcs/update.json.rabl
@@ -1,0 +1,3 @@
+object @auth_source_oidc
+
+extends 'api/v2/auth_source_oidcs/show'

--- a/app/views/api/v2/users/show.json.rabl
+++ b/app/views/api/v2/users/show.json.rabl
@@ -13,6 +13,11 @@ child :auth_source do
   extends "api/v2/auth_source_ldaps/base"
 end
 
+child :oidc_identities do
+  attributes :id, :auth_source_id, :subject, :email, :email_verified, :last_login_on
+  node(:auth_source_name) { |identity| identity.auth_source.name }
+end
+
 child :mail_notifications do
   extends "api/v2/mail_notifications/base"
 end

--- a/app/views/auth_source_oidcs/_form.html.erb
+++ b/app/views/auth_source_oidcs/_form.html.erb
@@ -1,0 +1,68 @@
+<%= form_for @auth_source_oidc do |f| %>
+  <%= base_errors_for @auth_source_oidc %>
+  <%= f.hidden_field :id if @auth_source_oidc.persisted? %>
+  <ul class="nav nav-tabs" data-tabs="tabs">
+    <li class="active"><a href="#provider" data-toggle="tab"><%= _('Provider') %></a></li>
+    <li><a href="#endpoints" data-toggle="tab"><%= _('Endpoints') %></a></li>
+    <li><a href="#claims" data-toggle="tab"><%= _('Claim mappings') %></a></li>
+    <li><a href="#provisioning" data-toggle="tab"><%= _('Provisioning') %></a></li>
+    <% if show_location_tab? %>
+      <li><a href="#locations" data-toggle="tab"><%= _('Locations') %></a></li>
+    <% end %>
+    <% if show_organization_tab? %>
+      <li><a href="#organizations" data-toggle="tab"><%= _('Organizations') %></a></li>
+    <% end %>
+  </ul>
+
+  <div class="tab-content">
+    <div class="tab-pane active" id="provider">
+      <%= text_f f, :name %>
+      <%= text_f f, :oidc_issuer, :label => _('Issuer'),
+        :help_inline => link_to_function(_('Test Connection'), "tfm.authSource.testConnection(this, '#{test_connection_auth_source_oidcs_url}')",
+          :title => _('Test OpenID Connect discovery'), :id => 'test_connection_button', :class => 'btn btn-success') + hidden_spinner('', :id => 'test_connection_indicator').html_safe %>
+      <%= text_f f, :oidc_client_id, :label => _('Client ID') %>
+      <%= password_f f, :oidc_client_secret, :label => _('Client secret'), :unset => %w[edit update].include?(action_name) %>
+      <%= select_f f, :oidc_client_auth_method, AuthSourceOidc::CLIENT_AUTH_METHODS, :first, :last, {}, :label => _('Token endpoint authentication') %>
+      <%= text_f f, :oidc_scopes, :label => _('Scopes'), :help_inline => _('Space-separated scopes; openid is required') %>
+      <%= text_f f, :oidc_allowed_algorithms, :label => _('Allowed signing algorithms'), :help_inline => _('Comma-separated allowlist, for example RS256') %>
+      <%= checkbox_f f, :oidc_enabled, :label => _('Enabled') %>
+      <%= checkbox_f f, :oidc_use_pkce, :label => _('Use PKCE'), :help_inline => _('Use the S256 proof key method for authorization code requests') %>
+      <%= textarea_f f, :cacert, :rows => 5, :label => _('CA certificate'),
+        :help_block => _('Optional PEM-encoded CA certificate(s). Leave blank to use the system trust store.') %>
+    </div>
+
+    <div class="tab-pane" id="endpoints">
+      <%= checkbox_f f, :oidc_use_discovery, :label => _('Use provider discovery'),
+        :help_inline => _('Load endpoints from the issuer .well-known/openid-configuration document') %>
+      <%= text_f f, :oidc_authorization_endpoint, :label => _('Authorization endpoint') %>
+      <%= text_f f, :oidc_token_endpoint, :label => _('Token endpoint') %>
+      <%= text_f f, :oidc_userinfo_endpoint, :label => _('UserInfo endpoint') %>
+      <%= text_f f, :oidc_jwks_uri, :label => _('JWKS URI') %>
+      <%= text_f f, :oidc_end_session_endpoint, :label => _('End session endpoint') %>
+    </div>
+
+    <div class="tab-pane" id="claims">
+      <%= text_f f, :oidc_login_claim, :label => _('Login claim') %>
+      <%= text_f f, :oidc_email_claim, :label => _('Email claim') %>
+      <%= text_f f, :oidc_firstname_claim, :label => _('First name claim') %>
+      <%= text_f f, :oidc_lastname_claim, :label => _('Last name claim') %>
+      <%= text_f f, :oidc_groups_claim, :label => _('Groups claim'), :help_inline => _('Dot notation can be used for nested claims') %>
+    </div>
+
+    <div class="tab-pane" id="provisioning">
+      <%= checkbox_f f, :onthefly_register, :label => _('Create users automatically') %>
+      <%= checkbox_f f, :oidc_link_verified_email, :label => _('Link users by verified email'),
+        :help_inline => _('Allow a new identity to link to one existing account only when the provider marks its email as verified') %>
+      <%= checkbox_f f, :oidc_update_user_attributes, :label => _('Update user attributes on login') %>
+      <%= checkbox_f f, :usergroup_sync, :label => _('Synchronize external user groups on login') %>
+      <%= checkbox_f f, :oidc_allow_api_bearer, :label => _('Accept bearer tokens for the API'),
+        :help_inline => _('Authenticate API requests by matching the signed token sub claim to a linked identity') %>
+      <%= text_f f, :oidc_api_audiences, :label => _('API audiences'),
+        :help_inline => _('Required when API bearer authentication is enabled. Use a dedicated API audience that differs from the browser client ID.') %>
+    </div>
+
+    <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @auth_source_oidc %>
+  </div>
+
+  <%= submit_or_cancel f, false, :cancel_path => auth_sources_path %>
+<% end %>

--- a/app/views/auth_source_oidcs/_oidc_card_kebab.html.erb
+++ b/app/views/auth_source_oidcs/_oidc_card_kebab.html.erb
@@ -1,0 +1,10 @@
+<div class="dropdown pull-right dropdown-kebab-pf">
+  <button class="btn btn-link dropdown-toggle" type="button" id="oidcKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="fa fa-ellipsis-v"></span>
+  </button>
+  <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="oidcKebab">
+    <li><%= link_to_if_authorized _('Create'), :controller => :auth_source_oidcs, :action => :new %></li>
+    <li role="separator" class="divider"></li>
+    <li><%= link_to _('OpenID Connect documentation'), 'https://openid.net/developers/how-connect-works/', :rel => 'external' %></li>
+  </ul>
+</div>

--- a/app/views/auth_source_oidcs/_oidc_table.html.erb
+++ b/app/views/auth_source_oidcs/_oidc_table.html.erb
@@ -1,0 +1,22 @@
+<table class="<%= table_css_classes('table-hover table-fixed') %>">
+  <thead>
+    <tr>
+      <th><%= s_('AuthSource|Name') %></th>
+      <th><%= _('Issuer') %></th>
+      <th><%= _('Enabled') %></th>
+      <th><%= _('Automatic account creation') %></th>
+      <th><%= _('Actions') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% auth_source_oidcs.each do |auth_source_oidc| %>
+      <tr>
+        <td><%= link_to_if_authorized trunc_with_tooltip(auth_source_oidc.name), hash_for_edit_auth_source_oidc_path(:id => auth_source_oidc) %></td>
+        <td class="ellipsis"><%= auth_source_oidc.oidc_issuer %></td>
+        <td><%= checked_icon auth_source_oidc.oidc_enabled %></td>
+        <td><%= checked_icon auth_source_oidc.onthefly_register %></td>
+        <td class="col-md-1"><%= action_buttons display_delete_if_authorized hash_for_auth_source_oidc_path(:id => auth_source_oidc), :data => { :confirm => _('Delete %s?') % auth_source_oidc.name } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/auth_source_oidcs/edit.html.erb
+++ b/app/views/auth_source_oidcs/edit.html.erb
@@ -1,0 +1,9 @@
+<%= breadcrumbs(
+  :items => [
+    { :caption => _('Authentication Sources'), :url => auth_sources_path },
+    { :caption => _('Edit %s') % @auth_source_oidc.to_label },
+  ],
+  :switchable => false
+) %>
+<% title _('Edit %s') % @auth_source_oidc.to_label %>
+<%= render :partial => 'form' %>

--- a/app/views/auth_source_oidcs/new.html.erb
+++ b/app/views/auth_source_oidcs/new.html.erb
@@ -1,0 +1,9 @@
+<%= breadcrumbs(
+  :items => [
+    { :caption => _('Authentication Sources'), :url => auth_sources_path },
+    { :caption => _('Create OpenID Connect Auth Source') },
+  ],
+  :switchable => false
+) %>
+<% title _('Create OpenID Connect Auth Source') %>
+<%= render :partial => 'form' %>

--- a/app/views/auth_sources/_auth_source_card.html.erb
+++ b/app/views/auth_sources/_auth_source_card.html.erb
@@ -7,13 +7,17 @@
       <% if auth_source.type == 'AuthSourceExternal' %>
         <%= render :partial => 'auth_source_externals/external_card_kebab', :locals => {:auth_source => auth_source, :users => users} %>
       <% end %>
+      <% if auth_source.type == 'AuthSourceOidc' %>
+        <%= render :partial => 'auth_source_oidcs/oidc_card_kebab', :locals => {:auth_source => auth_source, :users => users} %>
+      <% end %>
       <h2 class="card-pf-title text-center">
         <%= type_of_auth_source(auth_source) %>
       </h2>
       <div class="card-pf-items text-center">
         <div class="card-pf-item">
           <span class="pficon pficon-users"></span>
-          <span class="card-pf-item-text"><%= link_to_if_authorized(number_of_users_counter(users, auth_source.type), hash_for_users_path(:search => "auth_source_type = #{auth_source.type}")) %></span>
+          <% search = auth_source.type == 'AuthSourceOidc' ? 'has_oidc_identity = true' : "auth_source_type = #{auth_source.type}" %>
+          <span class="card-pf-item-text"><%= link_to_if_authorized(number_of_users_counter(users, auth_source.type), hash_for_users_path(:search => search)) %></span>
         </div>
       </div>
     </div>

--- a/app/views/auth_sources/index.html.erb
+++ b/app/views/auth_sources/index.html.erb
@@ -2,21 +2,28 @@
 <div class="container-fluid container-cards-pf">
   <div class="row row-cards-pf">
     <% @auth_sources.each do |auth_source| %>
-      <% if auth_source.type != 'AuthSourceLdap' %>
+      <% if !['AuthSourceLdap', 'AuthSourceOidc'].include?(auth_source.type) %>
         <%= render :partial => 'auth_source_card', :locals => {:auth_source => auth_source, :users => @users} %>
       <% end %>
     <% end %>
     <% if auth_source = ldap_present(@auth_sources) %>
       <%= render :partial => 'auth_source_card', :locals => {:auth_source => auth_source, :users => @users} %>
     <% end %>
+    <%= render :partial => 'auth_source_card', :locals => {:auth_source => AuthSourceOidc.new, :users => @users} %>
   </div>
+</div>
+
+<div>
+  <% if @auth_source_oidcs.any? %>
+    <%= render :partial => 'auth_source_oidcs/oidc_table', :locals => { :auth_source_oidcs => @auth_source_oidcs } %>
+  <% end %>
 </div>
 
 <div>
   <% if @auth_source_ldaps.any? %>
     <%= render :partial => 'auth_source_ldaps/ldap_table', :locals => {:auth_source_ldaps => @auth_source_ldaps} %>
     <%= will_paginate_with_info @auth_source_ldaps %>
-  <% else %>
+  <% elsif @auth_source_oidcs.empty? %>
     <%= render :partial => 'welcome' %>
   <% end %>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -21,6 +21,9 @@
     <% if @editing_self %>
       <li><a href='#jwt_tokens' data-toggle='tab'><%= _('Registration Tokens') %></a></li>
     <% end %>
+    <% if @user.persisted? && (@editing_self || User.current.can?(:edit_users)) %>
+      <li><a href='#oidc_identities' data-toggle='tab'><%= _('OpenID Connect Identities') %></a></li>
+    <% end %>
     <li><a href='#ui_preferences' data-toggle='tab'><%= _('UI Preferences') %></a></li>
     <%= render_tab_header_for(:main_tabs, :subject => @user, :form => f) %>
   </ul>
@@ -103,6 +106,41 @@
 
     <% if @editing_self %>
       <%= render 'jwt_tokens/jwt_tokens_tab', :f => f, :user => @user %>
+    <% end %>
+
+    <% if @user.persisted? && (@editing_self || User.current.can?(:edit_users)) %>
+      <div class='tab-pane' id='oidc_identities'>
+        <%= alert :class => 'alert-info', :header => '',
+          :text => _('An identity is unique within one provider. The subject is the stable sub claim supplied by that provider.'),
+          :close => false %>
+        <% if @editing_self %>
+          <table class="<%= table_css_classes('table-hover') %>">
+            <thead><tr><th><%= _('Provider') %></th><th><%= _('Subject') %></th><th><%= _('Last login') %></th></tr></thead>
+            <tbody>
+              <% @user.oidc_identities.includes(:auth_source).each do |identity| %>
+                <tr><td><%= identity.auth_source.name %></td><td><%= identity.subject %></td><td><%= date_time_unless_empty(identity.last_login_on) %></td></tr>
+              <% end %>
+            </tbody>
+          </table>
+          <% linked_source_ids = @user.oidc_identities.map(&:auth_source_id) %>
+          <% AuthSourceOidc.enabled.where.not(:id => linked_source_ids).order(:name).each do |auth_source| %>
+            <%= link_to _('Link %s') % auth_source.name, link_oidc_identity_path(:id => auth_source),
+              :method => :post, :class => 'btn btn-default' %>
+          <% end %>
+        <% else %>
+          <% identities = @user.oidc_identities.to_a + [@user.oidc_identities.build] %>
+          <%= f.fields_for :oidc_identities, identities do |identity_form| %>
+            <%= field_set_tag _('OpenID Connect identity') do %>
+              <%= select_f identity_form, :auth_source_id, AuthSourceOidc.with_taxonomy_scope.order(:name), :id, :name,
+                { :include_blank => true }, { :label => _('Provider') } %>
+              <%= text_f identity_form, :subject, :label => _('Subject') %>
+              <% if identity_form.object.persisted? %>
+                <%= checkbox_f identity_form, :_destroy, :label => _('Unlink identity') %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
     <% end %>
 
     <div class='tab-pane' id='roles'>

--- a/config/initializers/f_foreman_permissions.rb
+++ b/config/initializers/f_foreman_permissions.rb
@@ -5,6 +5,7 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :view_current_user, { :"api/v2/users" => [:show_current] }, public: :true
     map.permission :my_account, {
       :users => [:edit],
+      :oidc_authentications => [:link],
       :notification_recipients => [:index, :update, :destroy, :update_group_as_read, :destroy_group],
       :"api/v2/table_preferences" => [:show, :create, :update, :destroy, :index],
     }, :public => true
@@ -38,21 +39,29 @@ Foreman::AccessControl.map do |permission_set|
     ajax_actions = [:test_connection]
     map.permission :view_authenticators, {:auth_sources => [:index, :show, :welcome],
                                              :auth_source_ldaps => [:welcome],
+                                             :auth_source_oidcs => [:welcome],
                                              :"api/v2/auth_source_ldaps" => [:index, :show],
+                                             :"api/v2/auth_source_oidcs" => [:index, :show],
                                              :"api/v2/auth_sources" => [:index, :show],
                                              :"api/v2/auth_source_internals" => [:index, :show],
                                              :"api/v2/auth_source_externals" => [:index, :show],
     }
     map.permission :create_authenticators, {:auth_source_ldaps => [:new, :create].push(*ajax_actions),
                                              :"api/v2/auth_source_ldaps" => [:create],
+                                             :auth_source_oidcs => [:new, :create].push(*ajax_actions),
+                                             :"api/v2/auth_source_oidcs" => [:create],
     }
     map.permission :edit_authenticators, {:auth_source_ldaps => [:edit, :update].push(*ajax_actions),
+                                             :auth_source_oidcs => [:edit, :update].push(*ajax_actions),
                                              :auth_source_externals => [:edit, :update],
                                              :"api/v2/auth_source_ldaps" => [:update, :test],
+                                             :"api/v2/auth_source_oidcs" => [:update, :test],
                                              :"api/v2/auth_source_externals" => [:update],
     }
     map.permission :destroy_authenticators, {:auth_source_ldaps => [:destroy],
+                                             :auth_source_oidcs => [:destroy],
                                              :"api/v2/auth_source_ldaps" => [:destroy],
+                                             :"api/v2/auth_source_oidcs" => [:destroy],
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -292,8 +292,18 @@ Foreman::Application.routes.draw do
     end
   end
 
+  resources :auth_source_oidcs, :except => [:show, :index] do
+    collection do
+      put 'test_connection'
+    end
+  end
+
   resources :auth_sources, only: [:show, :index]
   resources :auth_source_externals, only: [:update, :edit]
+
+  post 'users/oidc/:id', :to => 'oidc_authentications#start', :as => :start_oidc_authentication
+  post 'users/oidc/:id/link', :to => 'oidc_authentications#link', :as => :link_oidc_identity
+  get 'users/oidc/callback', :to => 'oidc_authentications#callback', :as => :callback_oidc_authentications
 
   put 'users/(:id)/test_mail', to: 'users#test_mail', as: 'test_mail_user'
 

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -45,6 +45,13 @@ Foreman::Application.routes.draw do
         resources :external_usergroups, :except => [:new, :edit]
       end
 
+      resources :auth_source_oidcs, :except => [:new, :edit] do
+        resources :locations, :only => [:index, :show]
+        resources :organizations, :only => [:index, :show]
+        resources :users, :except => [:new, :edit]
+        resources :external_usergroups, :except => [:new, :edit]
+      end
+
       resources :bookmarks, :except => [:new, :edit]
 
       resources :common_parameters, :except => [:new, :edit]
@@ -349,6 +356,7 @@ Foreman::Application.routes.draw do
         # scoped by location
         resources :auth_sources, :only => [:index, :show]
         resources :auth_source_ldaps, :only => [:index, :show]
+        resources :auth_source_oidcs, :only => [:index, :show]
         resources :auth_source_externals, :only => [:index, :show]
         resources :domains, :only => [:index, :show]
         resources :realms, :only => [:index, :show]
@@ -373,6 +381,7 @@ Foreman::Application.routes.draw do
         resources :organizations, :except => [:new, :edit] do
           resources :auth_sources, :only => [:index, :show]
           resources :auth_source_ldaps, :only => [:index, :show]
+          resources :auth_source_oidcs, :only => [:index, :show]
           resources :auth_source_externals, :only => [:index, :show]
           resources :domains, :only => [:index, :show]
           resources :realms, :only => [:index, :show]
@@ -394,6 +403,7 @@ Foreman::Application.routes.draw do
         # scoped by organization
         resources :auth_sources, :only => [:index, :show]
         resources :auth_source_ldaps, :only => [:index, :show]
+        resources :auth_source_oidcs, :only => [:index, :show]
         resources :auth_source_externals, :only => [:index, :show]
         resources :domains, :only => [:index, :show]
         resources :realms, :only => [:index, :show]
@@ -418,6 +428,7 @@ Foreman::Application.routes.draw do
         resources :locations, :except => [:new, :edit] do
           resources :auth_sources, :only => [:index, :show]
           resources :auth_source_ldaps, :only => [:index, :show]
+          resources :auth_source_oidcs, :only => [:index, :show]
           resources :auth_source_externals, :only => [:index, :show]
           resources :domains, :only => [:index, :show]
           resources :realms, :only => [:index, :show]
@@ -441,6 +452,7 @@ Foreman::Application.routes.draw do
       get 'ping', :to => 'ping#ping'
       get 'statuses', :to => 'ping#statuses'
       put 'auth_source_ldaps/(:id)/test', :to => 'auth_source_ldaps#test'
+      put 'auth_source_oidcs/(:id)/test', :to => 'auth_source_oidcs#test'
       post 'registration_commands', to: 'registration_commands#create'
       get 'host_statuses', :to => 'host_statuses#index'
     end

--- a/db/migrate/20260829090000_add_openid_connect_authentication.rb
+++ b/db/migrate/20260829090000_add_openid_connect_authentication.rb
@@ -1,0 +1,42 @@
+class AddOpenidConnectAuthentication < ActiveRecord::Migration[7.0]
+  def change
+    change_table :auth_sources, :bulk => true do |t|
+      t.text :oidc_issuer
+      t.string :oidc_client_id
+      t.text :oidc_client_secret
+      t.string :oidc_scopes, :null => false, :default => 'openid profile email'
+      t.string :oidc_client_auth_method, :null => false, :default => 'client_secret_basic'
+      t.string :oidc_allowed_algorithms, :null => false, :default => 'RS256'
+      t.text :oidc_authorization_endpoint
+      t.text :oidc_token_endpoint
+      t.text :oidc_userinfo_endpoint
+      t.text :oidc_jwks_uri
+      t.text :oidc_end_session_endpoint
+      t.string :oidc_login_claim, :null => false, :default => 'preferred_username'
+      t.string :oidc_email_claim, :null => false, :default => 'email'
+      t.string :oidc_firstname_claim, :null => false, :default => 'given_name'
+      t.string :oidc_lastname_claim, :null => false, :default => 'family_name'
+      t.string :oidc_groups_claim, :null => false, :default => 'groups'
+      t.boolean :oidc_enabled, :null => false, :default => true
+      t.boolean :oidc_use_discovery, :null => false, :default => true
+      t.boolean :oidc_use_pkce, :null => false, :default => true
+      t.boolean :oidc_link_verified_email, :null => false, :default => false
+      t.boolean :oidc_update_user_attributes, :null => false, :default => true
+      t.boolean :oidc_allow_api_bearer, :null => false, :default => false
+      t.string :oidc_api_audiences
+    end
+
+    create_table :oidc_identities do |t|
+      t.references :user, :null => false, :foreign_key => { :on_delete => :cascade }
+      t.references :auth_source, :null => false, :foreign_key => { :on_delete => :cascade }
+      t.string :subject, :null => false
+      t.string :email
+      t.boolean :email_verified
+      t.datetime :last_login_on
+      t.timestamps
+    end
+
+    add_index :oidc_identities, [:auth_source_id, :subject], :unique => true
+    add_index :oidc_identities, [:user_id, :auth_source_id], :unique => true
+  end
+end

--- a/developer_docs/native_oidc_authentication.asciidoc
+++ b/developer_docs/native_oidc_authentication.asciidoc
@@ -1,0 +1,256 @@
+= Native OpenID Connect authentication
+
+Foreman can act as an OpenID Connect Relying Party for browser login. Providers
+are stored as authentication sources and are loaded dynamically, so adding or
+changing a provider does not require a Foreman restart. The existing bearer-token
+validation settings remain independent and continue to serve API and reverse-proxy
+authentication.
+
+== Supported flow and security properties
+
+The browser integration uses the Authorization Code flow. PKCE with S256 is
+enabled by default for confidential and public clients. Each request uses a
+random state and nonce, expires after ten minutes, and is bound to the Foreman
+session that started it. ID tokens are checked for:
+
+* a signature made by a configured, allowlisted algorithm and a key from the
+  provider JWKS;
+* exact issuer and client audience;
+* authorized party (`azp`) when required;
+* expiry, issued-at time, optional not-before time, and nonce;
+* optional access-token hash (`at_hash`).
+
+When UserInfo is available, its `sub` must match the ID token. HTTP requests use
+TLS certificate verification, the Foreman HTTP proxy settings and bounded
+timeouts. Redirects from provider endpoints are not followed. Access tokens,
+refresh tokens and ID tokens are never persisted.
+
+The implementation uses Foreman's existing `rest-client` and `jwt` dependencies.
+It does not add an OIDC client gem or change Faraday constraints, keeping the
+shared Foreman and Katello Bundler dependency graph compatible.
+
+== Common provider settings
+
+The examples in this document use `https://foreman.example.test` as the external
+Foreman URL. Replace it with the value configured in the `Foreman URL` setting.
+Register exact URLs instead of wildcard redirect patterns whenever the provider
+supports them.
+
+All providers need the following callback URL:
+
+----
+https://foreman.example.test/users/oidc/callback
+----
+
+Providers that validate the post-logout destination also need the Foreman login
+URL registered as an allowed sign-out or redirect URL:
+
+----
+https://foreman.example.test/users/login
+----
+
+In Foreman, navigate to *Administer > Authentication Sources*, create an OpenID
+Connect source and enter the issuer, client ID and client secret. Keep discovery
+and PKCE enabled unless the provider requires otherwise. The usual scopes are
+`openid profile email`; add a provider-specific groups scope when required.
+
+The default claim mappings are `preferred_username`, `email`, `given_name`,
+`family_name` and `groups`. Foreman merges claims from the ID token and UserInfo.
+Change the mappings when the provider uses different names. The groups claim must
+be either one string or an array of strings. Map those exact values to Foreman user
+groups through the existing external user group interface.
+
+The *Test Connection* action validates discovery and signing keys. Complete a real
+login before enabling automatic account linking or relying on group synchronization.
+
+== Configure Keycloak
+
+. In the intended realm, create a client with *OpenID Connect* as the client type.
+. Enable the *Standard flow*. Enable client authentication for a confidential
+  client, or use a public client with PKCE and select `none` as the token endpoint
+  authentication method in Foreman.
+. Add the Foreman callback as an exact *Valid Redirect URI* and the Foreman login
+  URL as a *Valid Post Logout Redirect URI*.
+. Ensure the `profile` and `email` scopes expose `preferred_username`, `given_name`,
+  `family_name`, `email`, and `email_verified`.
+. To synchronize groups, add a Group Membership mapper that emits a JSON array in
+  the `groups` claim. Limit the mapper to groups that are relevant to Foreman.
+
+Use the realm-specific issuer in Foreman:
+
+----
+https://keycloak.example.test/realms/example
+----
+
+For a confidential client, use `client_secret_basic` token endpoint authentication.
+Discovery fills the authorization, token, UserInfo, JWKS and end-session endpoints.
+A custom CA bundle can be supplied for an internal Keycloak deployment.
+
+For API bearer authentication, add an audience mapper that places the dedicated
+Foreman API audience in access tokens. Do not reuse the browser client ID as the
+API audience.
+
+See the
+https://www.keycloak.org/docs/latest/server_admin/#_oidc_clients[Keycloak Server
+Administration Guide] for current client, mapper and logout options.
+
+== Configure Microsoft Entra ID
+
+. In *Microsoft Entra ID > App registrations*, register a web application. A
+  single-tenant registration is recommended unless the Foreman deployment is
+  intentionally shared by several tenants.
+. Add both Foreman URLs from the common provider settings above as Web redirect URIs.
+  The login URL is required because Entra validates `post_logout_redirect_uri`
+  against the application's registered redirect URIs.
+. Create a client secret under *Certificates & secrets*.
+. Use a tenant-specific v2 issuer in Foreman:
++
+----
+https://login.microsoftonline.com/TENANT_ID/v2.0
+----
++
+Do not use `common` or `organizations`: Foreman validates the returned issuer
+exactly, while those authorities can issue a tenant-specific `iss` value.
+. Select `client_secret_post` token endpoint authentication and use
+  `openid profile email` scopes.
+
+Entra can omit the `email` claim for some account types. Add `email` as an optional
+ID-token claim when it is available, or map Foreman's email claim to
+`preferred_username` after verifying that it is a valid email address for every
+allowed user. Do not enable verified-email account linking unless the provider
+actually emits `email_verified` as the boolean value `true`.
+
+The Entra `groups` claim contains group object IDs by default. These IDs can be
+used directly as Foreman external group names. Alternatively, expose application
+roles and set Foreman's groups claim mapping to `roles`. Foreman does not follow
+Microsoft Graph group-overage references, so restrict emitted groups to those
+assigned to the application or prefer application roles for users with many group
+memberships.
+
+See the
+https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc[Microsoft
+identity platform OIDC reference] and
+https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims[Entra
+group claims guide].
+
+== Configure Okta
+
+. Create an *OIDC - OpenID Connect* application integration and select *Web
+  Application*.
+. Enable the Authorization Code grant and assign the users or groups that may log
+  in to Foreman.
+. Add the Foreman callback as a *Sign-in redirect URI* and the Foreman login URL
+  as a *Sign-out redirect URI*.
+. Copy the client ID and client secret to Foreman and select
+  `client_secret_basic` token endpoint authentication.
+. Use one issuer consistently. The organization authorization server uses:
++
+----
+https://example.okta.com
+----
++
+A custom authorization server uses an issuer such as:
++
+----
+https://example.okta.com/oauth2/default
+----
+. Use `openid profile email` scopes. If the groups claim is scope-dependent, add
+  `groups` to the Foreman scopes as well.
+
+To synchronize groups with the organization authorization server, configure the
+application's ID-token groups claim on the *Sign On* tab. Prefer a filter that
+only returns Foreman-related groups instead of `.*`. With a custom authorization
+server, create a groups claim that is always included in the ID token or returned
+by UserInfo. In both cases, keep the Foreman groups mapping set to the configured
+claim name.
+
+Use a custom authorization server with a dedicated audience when enabling API
+bearer authentication. Organization authorization-server access tokens are meant
+for Okta and must not be treated as Foreman API tokens.
+
+See the
+https://developer.okta.com/docs/guides/build-sso-integration/openidconnect/main/[Okta
+OIDC application guide] and
+https://developer.okta.com/docs/guides/customize-tokens-groups-claim/main/[Okta
+groups claim guide].
+
+== Configure Authentik
+
+. Create an OAuth2/OpenID Connect provider and associate it with a Foreman
+  application.
+. Use a confidential client and the Authorization Code flow. A public client is
+  also supported when PKCE is enabled and Foreman's token endpoint authentication
+  is set to `none`.
+. Configure the exact Foreman callback URI. Do not leave the redirect URI empty
+  and rely on first-use registration.
+. Keep Authentik's default per-provider issuer mode and use this issuer in Foreman:
++
+----
+https://authentik.example.test/application/o/foreman/
+----
+. For a confidential client, select `client_secret_basic` in Foreman and request
+  `openid profile email`. The default `profile` mapping includes the username and
+  group membership.
+
+Inspect the resulting claims before keeping the default first-name and last-name
+mappings. If the Authentik profile mapping does not emit `given_name` and
+`family_name`, create a scope mapping for those claims or update the Foreman claim
+names to match the custom mapping.
+
+Authentik 2025.10 and later correctly default `email_verified` to `false`. Only
+replace the email scope mapping with one that returns `true` when the underlying
+identity source genuinely verifies email addresses. Otherwise, leave Foreman's
+verified-email account linking disabled.
+
+RP-initiated logout ends the application's Authentik session. To end the main
+Authentik session and log out from other applications too, add a User Logout stage
+to Authentik's `default-provider-invalidation-flow` after assessing the effect on
+the other applications.
+
+See the
+https://docs.goauthentik.io/add-secure-apps/providers/oauth2/[Authentik OAuth2/OIDC
+provider guide] and
+https://docs.goauthentik.io/add-secure-apps/providers/single-logout/[Authentik
+single logout guide].
+
+== Accounts and identities
+
+Provider identity is keyed by the pair of authentication source and stable `sub`
+claim. It is stored separately from the user, allowing one Foreman user to link
+more than one provider without changing the user's primary authentication source.
+
+Accounts can be created on first login. Linking to an existing account by email is
+disabled by default and only succeeds when the provider explicitly marks that
+email as verified and exactly one Foreman account uses it. A signed-in user can
+link another configured provider by completing a fresh authentication request.
+Administrators can also manage provider and subject mappings on the user form.
+
+Mapped external user groups are reconciled on every login. Memberships managed by
+the current provider are added and removed to match the current claim. Memberships
+in local groups that are not mapped from the current provider are preserved.
+
+To migrate from Apache-based OpenID Connect, configure the native provider while
+the existing SSO method is still active. Existing signed-in users can link the new
+provider from their account page, or administrators can create the mappings. The
+Apache integration can be disabled after the required users have linked identities;
+the two authentication paths remain independent during the transition.
+
+== API
+
+OpenID Connect sources are available through `/api/v2/auth_source_oidcs`. The API
+supports list, show, create, update, delete and connection-test operations, plus
+the standard location, organization, user and external-user-group nested routes.
+User detail responses include linked identity IDs and subjects so administrators
+can update or unlink them. Client secrets are accepted on create and update but
+are never returned.
+
+An administrator can opt a provider into API bearer authentication and configure
+one or more accepted access-token audiences. Only identities that have already
+been linked through browser login or administration can authenticate this way;
+an API token never provisions or links a user. The older global OIDC bearer-token
+settings continue to work for deployments that use them.
+
+For Keycloak API access, add an audience mapper so the access token contains the
+dedicated Foreman API audience configured in the authentication source. Using an
+audience that is absent from browser ID tokens prevents those tokens from being
+accepted by the Foreman API.

--- a/test/controllers/api/v2/auth_source_oidcs_controller_test.rb
+++ b/test/controllers/api/v2/auth_source_oidcs_controller_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class Api::V2::AuthSourceOidcsControllerTest < ActionController::TestCase
+  setup do
+    @auth_source = FactoryBot.create(:auth_source_oidc)
+  end
+
+  test 'lists providers without client secrets' do
+    get :index
+
+    assert_response :success
+    response = ActiveSupport::JSON.decode(@response.body)
+    result = response['results'].find { |item| item['id'] == @auth_source.id }
+    assert_equal @auth_source.oidc_issuer, result['oidc_issuer']
+    refute result.key?('oidc_client_secret')
+  end
+
+  test 'creates a provider' do
+    assert_difference('AuthSourceOidc.count') do
+      post :create, :params => { :auth_source_oidc => FactoryBot.attributes_for(:auth_source_oidc) }
+    end
+
+    assert_response :created
+  end
+
+  test 'updates a provider without returning its secret' do
+    put :update, :params => { :id => @auth_source, :auth_source_oidc => { :oidc_scopes => 'openid email groups' } }
+
+    assert_response :success
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal 'openid email groups', response['oidc_scopes']
+    refute response.key?('oidc_client_secret')
+  end
+
+  test 'tests provider discovery' do
+    AuthSourceOidc.any_instance.stubs(:test_connection).returns(:message => 'success')
+
+    put :test, :params => { :id => @auth_source }
+
+    assert_response :success
+    assert ActiveSupport::JSON.decode(@response.body)['success']
+  end
+end

--- a/test/controllers/api/v2/users_controller_test.rb
+++ b/test/controllers/api/v2/users_controller_test.rb
@@ -29,6 +29,30 @@ class Api::V2::UsersControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'lists users linked to an OpenID Connect authentication source' do
+    auth_source = FactoryBot.create(:auth_source_oidc)
+    linked_user = FactoryBot.create(:user)
+    FactoryBot.create(:oidc_identity, :auth_source => auth_source, :user => linked_user)
+
+    get :index, :params => { :auth_source_oidc_id => auth_source.id }
+
+    assert_response :success
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert_includes response['results'].map { |user| user['id'] }, linked_user.id
+  end
+
+  test 'shows OpenID Connect identities for administration' do
+    user = FactoryBot.create(:user)
+    identity = FactoryBot.create(:oidc_identity, :user => user)
+
+    get :show, :params => { :id => user.id }
+
+    assert_response :success
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal identity.subject, response['oidc_identities'].first['subject']
+    assert_equal identity.auth_source.name, response['oidc_identities'].first['auth_source_name']
+  end
+
   test "should handle taxonomy with wrong id" do
     get :index, params: { :location_id => taxonomies(:location1).id, :organization_id => 'missing' }
     assert_response :not_found

--- a/test/controllers/auth_source_oidcs_controller_test.rb
+++ b/test/controllers/auth_source_oidcs_controller_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class AuthSourceOidcsControllerTest < ActionController::TestCase
+  setup do
+    @model = FactoryBot.create(:auth_source_oidc)
+  end
+
+  basic_new_test
+  basic_edit_test
+
+  test 'creates a provider' do
+    assert_difference('AuthSourceOidc.count') do
+      post :create, :params => { :auth_source_oidc => FactoryBot.attributes_for(:auth_source_oidc) },
+        :session => set_session_user
+    end
+
+    assert_redirected_to auth_sources_url
+  end
+
+  test 'does not return or erase an existing client secret on an unrelated update' do
+    old_secret = @model.oidc_client_secret
+
+    put :update, :params => { :id => @model, :auth_source_oidc => { :name => @model.name } },
+      :session => set_session_user
+
+    assert_redirected_to auth_sources_url
+    assert_equal old_secret, @model.reload.oidc_client_secret
+  end
+
+  test 'tests provider discovery' do
+    AuthSourceOidc.any_instance.stubs(:test_connection).returns(:success => true)
+
+    put :test_connection,
+      :params => { :auth_source_oidc => { :id => @model.id, :name => @model.name } },
+      :session => set_session_user
+
+    assert_response :success
+  end
+
+  test 'requires edit permission when testing an existing provider' do
+    @controller.stubs(:params).returns(ActionController::Parameters.new(
+      :action => 'test_connection', :auth_source_oidc => { :id => @model.id }
+    ))
+
+    assert_equal 'edit', @controller.send(:action_permission)
+  end
+
+  test 'requires create permission when testing a new provider' do
+    @controller.stubs(:params).returns(ActionController::Parameters.new(
+      :action => 'test_connection', :auth_source_oidc => {}
+    ))
+
+    assert_equal 'create', @controller.send(:action_permission)
+  end
+
+  test 'reports provider discovery errors' do
+    AuthSourceOidc.any_instance.stubs(:test_connection).raises(Foreman::Exception, 'Discovery failed')
+
+    put :test_connection,
+      :params => { :auth_source_oidc => { :id => @model.id, :name => @model.name } },
+      :session => set_session_user
+
+    assert_response :unprocessable_entity
+  end
+
+  test 'does not delete a provider with linked identities' do
+    FactoryBot.create(:oidc_identity, :auth_source => @model)
+
+    assert_no_difference('AuthSourceOidc.count') do
+      delete :destroy, :params => { :id => @model }, :session => set_session_user
+    end
+  end
+
+  test 'does not delete a provider used as a primary authentication source' do
+    FactoryBot.create(:user, :auth_source => @model)
+
+    assert_no_difference('AuthSourceOidc.count') do
+      delete :destroy, :params => { :id => @model }, :session => set_session_user
+    end
+  end
+end

--- a/test/controllers/oidc_authentications_controller_test.rb
+++ b/test/controllers/oidc_authentications_controller_test.rb
@@ -1,0 +1,119 @@
+require 'test_helper'
+
+class OidcAuthenticationsControllerTest < ActionController::TestCase
+  setup do
+    @auth_source = FactoryBot.create(:auth_source_oidc)
+  end
+
+  test 'starts an authorization request and stores its state' do
+    request = mock('authorization request')
+    request.stubs(:session_data).returns(
+      'auth_source_id' => @auth_source.id,
+      'state' => 'state-1',
+      'nonce' => 'nonce-1',
+      'created_at' => Time.now.utc.to_i
+    )
+    request.stubs(:url).returns('https://idp.example.test/authorize')
+    Oidc::AuthorizationRequest.stubs(:new).returns(request)
+
+    post :start, :params => { :id => @auth_source.to_param }
+
+    assert_redirected_to 'https://idp.example.test/authorize'
+    assert_equal @auth_source.id, session[:oidc_authentications]['state-1']['auth_source_id']
+  end
+
+  test 'rejects a callback without matching state before exchanging a code' do
+    Oidc::Authenticator.expects(:new).never
+
+    get :callback, :params => { :state => 'unknown', :code => 'code' }
+
+    assert_redirected_to login_users_path
+    assert flash[:inline][:error].present?
+  end
+
+  test 'rejects an account linking callback without matching state' do
+    user = FactoryBot.create(:user)
+    Oidc::Authenticator.expects(:new).never
+
+    assert_difference -> { Audit.where(:action => 'failed_link').count } do
+      get :callback,
+        :params => { :state => 'unknown', :code => 'code' },
+        :session => { :user => user.id }
+    end
+
+    assert_redirected_to edit_user_path(:id => user)
+    assert flash[:inline][:error].present?
+  end
+
+  test 'uses the configured Foreman URL for the redirect URI' do
+    Setting.stubs(:[]).with(:foreman_url).returns('https://foreman.example.test/')
+
+    assert_equal 'https://foreman.example.test/users/oidc/callback', @controller.send(:callback_url)
+  end
+
+  test 'authenticates a valid callback and synchronizes groups' do
+    user = FactoryBot.create(:user)
+    authentication = authentication_result
+    authenticator = mock('authenticator')
+    authenticator.expects(:authenticate).with('code', 'nonce-1', 'verifier').returns(authentication)
+    Oidc::Authenticator.stubs(:new).returns(authenticator)
+    resolver = mock('resolver')
+    resolver.expects(:resolve).returns(Oidc::UserResolver::Result.new(:user => user, :created => false))
+    Oidc::UserResolver.stubs(:new).returns(resolver)
+    AuthSourceOidc.any_instance.expects(:sync_usergroups).with(user, ['admins'])
+
+    get :callback,
+      :params => { :state => 'state-1', :code => 'code' },
+      :session => callback_session
+
+    assert_redirected_to ApplicationHelper.current_hosts_path
+    assert_equal user.id, session[:user]
+    assert_equal @auth_source.id, session[:oidc_auth_source_id]
+  end
+
+  test 'links an additional provider after a fresh authentication' do
+    user = FactoryBot.create(:user)
+    authentication = authentication_result
+    authenticator = mock('authenticator')
+    authenticator.stubs(:authenticate).returns(authentication)
+    Oidc::Authenticator.stubs(:new).returns(authenticator)
+    linker = mock('identity linker')
+    linker.expects(:link).returns(FactoryBot.build_stubbed(:oidc_identity, :user => user, :auth_source => @auth_source))
+    Oidc::IdentityLinker.stubs(:new).returns(linker)
+    AuthSourceOidc.any_instance.stubs(:sync_usergroups)
+
+    get :callback,
+      :params => { :state => 'state-1', :code => 'code' },
+      :session => callback_session.merge(:user => user.id).deep_merge(
+        :oidc_authentications => { 'state-1' => callback_flow.merge('link_user_id' => user.id) }
+      )
+
+    assert_redirected_to edit_user_path(:id => user)
+  end
+
+  private
+
+  def authentication_result
+    Oidc::Authenticator::Result.new(
+      :claims => {},
+      :subject => 'subject-1',
+      :email => 'user@example.test',
+      :email_verified => true,
+      :groups => ['admins']
+    )
+  end
+
+  def callback_flow
+    {
+      'auth_source_id' => @auth_source.id,
+      'state' => 'state-1',
+      'nonce' => 'nonce-1',
+      'code_verifier' => 'verifier',
+      'created_at' => Time.now.utc.to_i,
+    }
+  end
+
+  def callback_session
+    { :oidc_authentications => { 'state-1' => callback_flow } }
+  end
+end

--- a/test/factories/auth_source_oidc.rb
+++ b/test/factories/auth_source_oidc.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :auth_source_oidc do
+    sequence(:name) { |number| "oidc_#{number}" }
+    sequence(:oidc_issuer) { |number| "https://idp#{number}.example.test/realms/foreman" }
+    sequence(:oidc_client_id) { |number| "foreman-#{number}" }
+    oidc_client_secret { 'secret' }
+    oidc_scopes { 'openid profile email' }
+    oidc_client_auth_method { 'client_secret_basic' }
+    oidc_allowed_algorithms { 'RS256' }
+    oidc_enabled { true }
+    oidc_use_discovery { true }
+    oidc_use_pkce { true }
+  end
+end

--- a/test/factories/oidc_identity.rb
+++ b/test/factories/oidc_identity.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :oidc_identity do
+    user
+    association :auth_source, :factory => :auth_source_oidc
+    sequence(:subject) { |number| "subject-#{number}" }
+    sequence(:email) { |number| "oidc-#{number}@example.test" }
+    email_verified { true }
+  end
+end

--- a/test/models/auth_sources/auth_source_oidc_test.rb
+++ b/test/models/auth_sources/auth_source_oidc_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class AuthSourceOidcTest < ActiveSupport::TestCase
+  let(:auth_source) { FactoryBot.build(:auth_source_oidc) }
+
+  should validate_presence_of(:name)
+  should validate_presence_of(:oidc_issuer)
+  should validate_presence_of(:oidc_client_id)
+  should have_many(:organizations)
+  should have_many(:locations)
+  should have_many(:oidc_identities)
+  should have_many(:linked_users).through(:oidc_identities)
+
+  test 'accepts a standard confidential client' do
+    assert auth_source.valid?, auth_source.errors.full_messages.to_sentence
+  end
+
+  test 'requires HTTPS issuer URLs' do
+    auth_source.oidc_issuer = 'http://keycloak.example.test/realms/foreman'
+
+    refute auth_source.valid?
+    assert auth_source.errors[:oidc_issuer].present?
+  end
+
+  test 'rejects issuer identifiers containing credentials, queries, or fragments' do
+    [
+      'https://user:password@keycloak.example.test/realms/foreman',
+      'https://keycloak.example.test/realms/foreman?tenant=one',
+      'https://keycloak.example.test/realms/foreman#issuer',
+    ].each do |issuer|
+      auth_source.oidc_issuer = issuer
+      refute auth_source.valid?
+      assert auth_source.errors[:oidc_issuer].present?
+    end
+  end
+
+  test 'requires the openid scope' do
+    auth_source.oidc_scopes = 'profile email'
+
+    refute auth_source.valid?
+    assert_includes auth_source.errors[:oidc_scopes], 'must include the openid scope'
+  end
+
+  test 'allows a public client without a secret' do
+    auth_source.oidc_client_auth_method = 'none'
+
+    assert auth_source.valid?, auth_source.errors.full_messages.to_sentence
+    assert_nil auth_source.oidc_client_secret
+  end
+
+  test 'requires PKCE for public clients' do
+    auth_source.oidc_client_auth_method = 'none'
+    auth_source.oidc_client_secret = nil
+    auth_source.oidc_use_pkce = false
+
+    refute auth_source.valid?
+    assert auth_source.errors[:oidc_use_pkce].present?
+  end
+
+  test 'rejects unsupported ID token algorithms' do
+    ['none', 'HS256', 'unknown'].each do |algorithm|
+      auth_source.oidc_allowed_algorithms = algorithm
+      refute auth_source.valid?
+      assert auth_source.errors[:oidc_allowed_algorithms].present?
+    end
+  end
+
+  test 'requires an explicit audience for API bearer authentication' do
+    auth_source.oidc_allow_api_bearer = true
+    auth_source.oidc_api_audiences = nil
+
+    refute auth_source.valid?
+    assert auth_source.errors[:oidc_api_audiences].present?
+  end
+
+  test 'does not accept browser ID tokens as API bearer tokens' do
+    auth_source.oidc_allow_api_bearer = true
+    auth_source.oidc_api_audiences = auth_source.oidc_client_id
+
+    refute auth_source.valid?
+    assert auth_source.errors[:oidc_api_audiences].present?
+  end
+
+  test 'requires endpoints when discovery is disabled' do
+    auth_source.oidc_use_discovery = false
+
+    refute auth_source.valid?
+    assert auth_source.errors[:oidc_authorization_endpoint].present?
+    assert auth_source.errors[:oidc_token_endpoint].present?
+    assert auth_source.errors[:oidc_jwks_uri].present?
+  end
+
+  test 'stores the client secret encrypted' do
+    AuthSourceOidc.any_instance.stubs(:encryption_key).returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+    auth_source.save!
+
+    assert auth_source.is_decryptable?(auth_source.oidc_client_secret_in_db)
+    refute_equal 'secret', auth_source.oidc_client_secret_in_db
+  end
+
+  test 'tests discovery and the provider key set' do
+    metadata = { 'jwks_uri' => 'https://idp.example.test/certs' }
+    auth_source.expects(:metadata).with(:force => true).returns(metadata)
+    verifier = mock('JWT verifier')
+    Oidc::JwtVerifier.expects(:new).with(auth_source).returns(verifier)
+    verifier.expects(:validate).with(:jwks_uri => metadata['jwks_uri'], :force => true).returns(true)
+
+    assert auth_source.test_connection[:success]
+  end
+
+  test 'synchronizes mapped groups and preserves local groups' do
+    auth_source.save!
+    user = FactoryBot.create(:user)
+    local_group = FactoryBot.create(:usergroup)
+    old_mapping = FactoryBot.create(:external_usergroup, :name => 'old', :auth_source => auth_source)
+    new_mapping = FactoryBot.create(:external_usergroup, :name => 'KEYCLOAK-ADMINS', :auth_source => auth_source)
+    user.usergroup_ids = [local_group.id, old_mapping.usergroup_id]
+
+    auth_source.sync_usergroups(user, ['keycloak-admins'])
+
+    assert_includes user.reload.usergroup_ids, local_group.id
+    assert_includes user.usergroup_ids, new_mapping.usergroup_id
+    refute_includes user.usergroup_ids, old_mapping.usergroup_id
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1147,6 +1147,15 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [user], User.search_for("usergroup = #{user.usergroups.first.name}")
   end
 
+  test 'can search users with OpenID Connect identities without duplicates' do
+    user = FactoryBot.create(:user)
+    FactoryBot.create(:oidc_identity, :user => user)
+    FactoryBot.create(:oidc_identity, :user => user)
+
+    assert_equal [user], User.unscoped.search_for('has_oidc_identity = true').to_a
+    refute_includes User.unscoped.search_for('has_oidc_identity = false'), user
+  end
+
   test 'can set valid timezone' do
     timezone = "Fiji"
     user = users(:one)

--- a/test/services/oidc/access_token_verifier_test.rb
+++ b/test/services/oidc/access_token_verifier_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Oidc::AccessTokenVerifierTest < ActiveSupport::TestCase
+  let(:auth_source) { FactoryBot.build_stubbed(:auth_source_oidc, :oidc_api_audiences => 'foreman-api') }
+  let(:jwt_verifier) { mock('JWT verifier') }
+
+  test 'validates required claims with the configured audience' do
+    payload = {
+      'sub' => 'subject-1',
+      'iss' => auth_source.oidc_issuer,
+      'aud' => 'foreman-api',
+      'exp' => 5.minutes.from_now.to_i,
+      'iat' => Time.now.utc.to_i,
+    }
+    Oidc::JwtVerifier.stubs(:new).with(auth_source).returns(jwt_verifier)
+    jwt_verifier.expects(:decode).with('token', :audience => ['foreman-api']).returns(payload)
+
+    assert_equal payload, Oidc::AccessTokenVerifier.new(auth_source).verify('token')
+  end
+
+  test 'rejects tokens without a subject' do
+    Oidc::JwtVerifier.stubs(:new).returns(jwt_verifier)
+    jwt_verifier.stubs(:decode).returns(
+      'iss' => auth_source.oidc_issuer,
+      'aud' => 'foreman-api',
+      'exp' => 5.minutes.from_now.to_i,
+      'iat' => Time.now.utc.to_i
+    )
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::AccessTokenVerifier.new(auth_source).verify('token')
+    end
+  end
+end

--- a/test/services/oidc/authenticator_test.rb
+++ b/test/services/oidc/authenticator_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class Oidc::AuthenticatorTest < ActiveSupport::TestCase
+  let(:auth_source) { FactoryBot.build_stubbed(:auth_source_oidc, :oidc_client_id => 'foreman', :oidc_client_secret => 'secret') }
+  let(:http_client) { mock('HTTP client') }
+  let(:token_verifier) { mock('token verifier') }
+  let(:metadata) do
+    {
+      'token_endpoint' => 'https://idp.example.test/token',
+      'userinfo_endpoint' => 'https://idp.example.test/userinfo',
+    }
+  end
+
+  setup do
+    auth_source.stubs(:metadata).returns(metadata)
+    Oidc::HttpClient.stubs(:new).with(auth_source).returns(http_client)
+    Oidc::TokenVerifier.stubs(:new).with(auth_source).returns(token_verifier)
+  end
+
+  test 'exchanges the authorization code and combines matching UserInfo claims' do
+    http_client.expects(:post_form).with(
+      metadata['token_endpoint'],
+      includes(:grant_type => 'authorization_code', :code => 'code', :code_verifier => 'verifier'),
+      includes(:authorization)
+    ).returns('id_token' => 'id-token', 'access_token' => 'access-token', 'token_type' => 'Bearer')
+    token_verifier.expects(:verify).with('id-token', 'nonce', 'access-token').returns(
+      'sub' => 'subject-1', 'preferred_username' => 'user'
+    )
+    http_client.expects(:get_json)
+      .with(metadata['userinfo_endpoint'], :authorization => 'Bearer access-token')
+      .returns('sub' => 'subject-1', 'email' => 'user@example.test', 'email_verified' => true, 'groups' => ['admins'])
+
+    result = Oidc::Authenticator.new(auth_source, 'https://foreman.example.test/users/oidc/callback')
+      .authenticate('code', 'nonce', 'verifier')
+
+    assert_equal 'subject-1', result.subject
+    assert_equal 'user@example.test', result.email
+    assert result.email_verified
+    assert_equal ['admins'], result.groups
+  end
+
+  test 'sends public client identification in the request body' do
+    auth_source.oidc_client_auth_method = 'none'
+    http_client.expects(:post_form).with(
+      metadata['token_endpoint'],
+      includes(:client_id => auth_source.oidc_client_id),
+      { :content_type => 'application/x-www-form-urlencoded' }
+    ).returns('id_token' => 'id-token')
+    token_verifier.stubs(:verify).returns('sub' => 'subject-1')
+
+    Oidc::Authenticator.new(auth_source, 'https://foreman.example.test/users/oidc/callback')
+      .authenticate('code', 'nonce')
+  end
+
+  test 'rejects UserInfo for a different subject' do
+    http_client.stubs(:post_form).returns('id_token' => 'id-token', 'access_token' => 'access-token', 'token_type' => 'Bearer')
+    token_verifier.stubs(:verify).returns('sub' => 'subject-1')
+    http_client.stubs(:get_json).returns('sub' => 'subject-2')
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::Authenticator.new(auth_source, 'https://foreman.example.test/users/oidc/callback')
+        .authenticate('code', 'nonce')
+    end
+  end
+
+  test 'rejects a non-bearer access token' do
+    http_client.stubs(:post_form).returns('id_token' => 'id-token', 'access_token' => 'access-token', 'token_type' => 'MAC')
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::Authenticator.new(auth_source, 'https://foreman.example.test/users/oidc/callback')
+      .authenticate('code', 'nonce')
+    end
+  end
+
+  test 'ignores non-string and oversized group claims' do
+    http_client.stubs(:post_form).returns('id_token' => 'id-token', 'access_token' => 'access-token', 'token_type' => 'Bearer')
+    token_verifier.stubs(:verify).returns('sub' => 'subject-1')
+    http_client.stubs(:get_json).returns(
+      'sub' => 'subject-1', 'groups' => ['admins', { 'name' => 'invalid' }, 'x' * 256]
+    )
+
+    result = Oidc::Authenticator.new(auth_source, 'https://foreman.example.test/users/oidc/callback')
+      .authenticate('code', 'nonce')
+
+    assert_equal ['admins'], result.groups
+  end
+end

--- a/test/services/oidc/authorization_request_test.rb
+++ b/test/services/oidc/authorization_request_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Oidc::AuthorizationRequestTest < ActiveSupport::TestCase
+  test 'builds an authorization code request with state, nonce, and PKCE' do
+    auth_source = FactoryBot.build_stubbed(:auth_source_oidc)
+    auth_source.stubs(:metadata).returns('authorization_endpoint' => 'https://idp.example.test/authorize')
+
+    request = Oidc::AuthorizationRequest.new(auth_source, 'https://foreman.example.test/users/oidc/callback')
+    query = Rack::Utils.parse_query(URI.parse(request.url).query)
+
+    assert_equal 'code', query['response_type']
+    assert_equal auth_source.oidc_client_id, query['client_id']
+    assert_equal 'S256', query['code_challenge_method']
+    assert query['code_challenge'].present?
+    assert_equal query['state'], request.session_data['state']
+    assert request.session_data['nonce'].present?
+    assert request.session_data['code_verifier'].present?
+  end
+end

--- a/test/services/oidc/http_client_test.rb
+++ b/test/services/oidc/http_client_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class Oidc::HttpClientTest < ActiveSupport::TestCase
+  let(:auth_source) { FactoryBot.build_stubbed(:auth_source_oidc, :cacert => nil) }
+  let(:client) { Oidc::HttpClient.new(auth_source) }
+
+  test 'loads a bounded JSON object over HTTPS' do
+    stub_request(:get, 'https://idp.example.test/configuration')
+      .to_return(:body => { :issuer => 'https://idp.example.test' }.to_json)
+
+    response = client.get_json('https://idp.example.test/configuration')
+
+    assert_equal 'https://idp.example.test', response['issuer']
+  end
+
+  test 'rejects unencrypted endpoints' do
+    assert_raises(Oidc::ConfigurationError) do
+      client.get_json('http://idp.example.test/configuration')
+    end
+  end
+
+  test 'rejects endpoint credentials and fragments' do
+    assert_raises(Oidc::ConfigurationError) do
+      client.get_json('https://user:password@idp.example.test/configuration')
+    end
+    assert_raises(Oidc::ConfigurationError) do
+      client.get_json('https://idp.example.test/configuration#fragment')
+    end
+  end
+
+  test 'does not follow provider redirects' do
+    stub_request(:get, 'https://idp.example.test/configuration')
+      .to_return(:status => 302, :headers => { 'Location' => 'https://other.example.test/configuration' })
+
+    assert_raises(Oidc::AuthenticationError) do
+      client.get_json('https://idp.example.test/configuration')
+    end
+    assert_not_requested :get, 'https://other.example.test/configuration'
+  end
+
+  test 'rejects non-object JSON' do
+    stub_request(:get, 'https://idp.example.test/configuration').to_return(:body => [].to_json)
+
+    assert_raises(Oidc::AuthenticationError) do
+      client.get_json('https://idp.example.test/configuration')
+    end
+  end
+end

--- a/test/services/oidc/identity_linker_test.rb
+++ b/test/services/oidc/identity_linker_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class Oidc::IdentityLinkerTest < ActiveSupport::TestCase
+  let(:auth_source) { FactoryBot.create(:auth_source_oidc) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:authentication) do
+    Oidc::Authenticator::Result.new(
+      :claims => {},
+      :subject => 'subject-1',
+      :email => 'user@example.test',
+      :email_verified => true,
+      :groups => []
+    )
+  end
+
+  test 'links a provider identity without changing the primary authentication source' do
+    original_auth_source = user.auth_source
+
+    identity = Oidc::IdentityLinker.new(auth_source, authentication, user).link
+
+    assert_equal user, identity.user
+    assert_equal auth_source, identity.auth_source
+    assert_equal original_auth_source, user.reload.auth_source
+  end
+
+  test 'is idempotent for the same user and provider' do
+    first = Oidc::IdentityLinker.new(auth_source, authentication, user).link
+    second = Oidc::IdentityLinker.new(auth_source, authentication, user).link
+
+    assert_equal first, second
+  end
+
+  test 'does not move an identity between users' do
+    Oidc::IdentityLinker.new(auth_source, authentication, user).link
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::IdentityLinker.new(auth_source, authentication, FactoryBot.create(:user)).link
+    end
+  end
+end

--- a/test/services/oidc/jwt_verifier_test.rb
+++ b/test/services/oidc/jwt_verifier_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class Oidc::JwtVerifierTest < ActiveSupport::TestCase
+  let(:auth_source) do
+    FactoryBot.build_stubbed(:auth_source_oidc,
+      :oidc_issuer => 'https://idp.example.test',
+      :oidc_client_id => 'foreman')
+  end
+  let(:jwks_uri) { 'https://idp.example.test/certs' }
+  let(:old_key) { JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)) }
+  let(:new_key) { JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)) }
+
+  setup do
+    auth_source.stubs(:metadata).returns('jwks_uri' => jwks_uri)
+    Rails.cache.delete(Oidc::JwtVerifier.cache_key(auth_source.id))
+  end
+
+  teardown do
+    Rails.cache.delete(Oidc::JwtVerifier.cache_key(auth_source.id))
+  end
+
+  test 'reloads the key set once when the provider rotates keys' do
+    cache_keys(old_key)
+    stub_request(:get, jwks_uri).to_return(:body => { :keys => [new_key.export] }.to_json)
+    token = encode(valid_payload, new_key)
+
+    assert_equal 'subject-1', verifier.decode(token, :audience => 'foreman')['sub']
+    assert_requested :get, jwks_uri, :times => 1
+  end
+
+  test 'does not reload keys for an expired token' do
+    cache_keys(new_key)
+    token = encode(valid_payload.merge('exp' => 5.minutes.ago.to_i), new_key)
+
+    assert_raises(JWT::ExpiredSignature) { verifier.decode(token, :audience => 'foreman') }
+    assert_not_requested :get, jwks_uri
+  end
+
+  private
+
+  def verifier
+    @verifier ||= Oidc::JwtVerifier.new(auth_source)
+  end
+
+  def cache_keys(key)
+    Rails.cache.write(Oidc::JwtVerifier.cache_key(auth_source.id), :keys => [key.export])
+  end
+
+  def encode(payload, key)
+    JWT.encode(payload, key.keypair, 'RS256', 'kid' => key.kid)
+  end
+
+  def valid_payload
+    {
+      'sub' => 'subject-1',
+      'iss' => auth_source.oidc_issuer,
+      'aud' => auth_source.oidc_client_id,
+      'exp' => 5.minutes.from_now.to_i,
+      'iat' => Time.now.utc.to_i,
+    }
+  end
+end

--- a/test/services/oidc/logout_url_test.rb
+++ b/test/services/oidc/logout_url_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class Oidc::LogoutURLTest < ActiveSupport::TestCase
+  let(:auth_source) do
+    stub(
+      'auth source',
+      :metadata => {
+        'end_session_endpoint' => 'https://idp.example.test/logout?prompt=logout&client_id=old',
+      },
+      :oidc_client_id => 'foreman'
+    )
+  end
+
+  test 'builds the provider logout URL' do
+    url = Oidc::LogoutURL.new(auth_source, 'https://foreman.example.test/users/login').to_s
+    uri = URI.parse(url)
+    parameters = URI.decode_www_form(uri.query).to_h
+
+    assert_equal 'https', uri.scheme
+    assert_equal 'idp.example.test', uri.host
+    assert_equal '/logout', uri.path
+    assert_equal 'logout', parameters['prompt']
+    assert_equal 'foreman', parameters['client_id']
+    assert_equal 'https://foreman.example.test/users/login', parameters['post_logout_redirect_uri']
+  end
+
+  test 'returns nil when the provider has no logout endpoint' do
+    auth_source.stubs(:metadata).returns({})
+
+    assert_nil Oidc::LogoutURL.new(auth_source, 'https://foreman.example.test/users/login').to_s
+  end
+end

--- a/test/services/oidc/provider_metadata_test.rb
+++ b/test/services/oidc/provider_metadata_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class Oidc::ProviderMetadataTest < ActiveSupport::TestCase
+  let(:auth_source) { FactoryBot.build_stubbed(:auth_source_oidc, :oidc_issuer => 'https://idp.example.test/realms/foreman') }
+  let(:client) { mock('http client') }
+  let(:metadata) do
+    {
+      'issuer' => auth_source.oidc_issuer,
+      'authorization_endpoint' => 'https://idp.example.test/authorize',
+      'token_endpoint' => 'https://idp.example.test/token',
+      'jwks_uri' => 'https://idp.example.test/certs',
+      'userinfo_endpoint' => 'https://idp.example.test/userinfo',
+      'code_challenge_methods_supported' => ['S256'],
+      'response_types_supported' => ['code'],
+      'id_token_signing_alg_values_supported' => ['RS256'],
+    }
+  end
+
+  setup do
+    Oidc::HttpClient.stubs(:new).with(auth_source).returns(client)
+    client.stubs(:validate_url!).with(anything).returns(true)
+  end
+
+  test 'loads and validates discovery metadata' do
+    client.expects(:get_json)
+      .with('https://idp.example.test/realms/foreman/.well-known/openid-configuration')
+      .returns(metadata)
+
+    result = Oidc::ProviderMetadata.new(auth_source).fetch(:force => true)
+
+    assert_equal metadata['authorization_endpoint'], result['authorization_endpoint']
+  end
+
+  test 'rejects a mismatched discovered issuer' do
+    client.stubs(:get_json).returns(metadata.merge('issuer' => 'https://attacker.example.test'))
+
+    assert_raises(Oidc::ConfigurationError) do
+      Oidc::ProviderMetadata.new(auth_source).fetch(:force => true)
+    end
+  end
+
+  test 'rejects providers without PKCE S256 support' do
+    client.stubs(:get_json).returns(metadata.merge('code_challenge_methods_supported' => ['plain']))
+
+    assert_raises(Oidc::ConfigurationError) do
+      Oidc::ProviderMetadata.new(auth_source).fetch(:force => true)
+    end
+  end
+
+  test 'validates optional endpoints before using them' do
+    client.expects(:get_json).returns(metadata.merge('end_session_endpoint' => 'https://idp.example.test/logout'))
+    client.expects(:validate_url!).with('https://idp.example.test/logout')
+
+    Oidc::ProviderMetadata.new(auth_source).fetch(:force => true)
+  end
+
+  test 'rejects providers without a configured signing algorithm' do
+    client.stubs(:get_json).returns(metadata.merge('id_token_signing_alg_values_supported' => ['ES256']))
+
+    assert_raises(Oidc::ConfigurationError) do
+      Oidc::ProviderMetadata.new(auth_source).fetch(:force => true)
+    end
+  end
+end

--- a/test/services/oidc/token_verifier_test.rb
+++ b/test/services/oidc/token_verifier_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class Oidc::TokenVerifierTest < ActiveSupport::TestCase
+  let(:key) { JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)) }
+  let(:auth_source) do
+    FactoryBot.build_stubbed(:auth_source_oidc,
+      :oidc_issuer => 'https://idp.example.test',
+      :oidc_client_id => 'foreman')
+  end
+  let(:verifier) { Oidc::TokenVerifier.new(auth_source) }
+  let(:nonce) { 'expected-nonce' }
+
+  setup do
+    Oidc::JwtVerifier.any_instance.stubs(:jwks).returns(:keys => [key.export])
+  end
+
+  test 'verifies the signature and required OpenID Connect claims' do
+    payload = valid_payload
+    token = JWT.encode(payload, key.keypair, 'RS256', 'kid' => key.kid)
+
+    assert_equal payload, verifier.verify(token, nonce)
+  end
+
+  test 'rejects a wrong nonce' do
+    token = JWT.encode(valid_payload.merge('nonce' => 'wrong'), key.keypair, 'RS256', 'kid' => key.kid)
+
+    assert_raises(Oidc::AuthenticationError) { verifier.verify(token, nonce) }
+  end
+
+  test 'rejects malformed subjects and timestamps' do
+    [
+      valid_payload.merge('sub' => ['subject-1']),
+      valid_payload.merge('iat' => Time.now.utc.to_i.to_s),
+    ].each do |payload|
+      token = JWT.encode(payload, key.keypair, 'RS256', 'kid' => key.kid)
+      assert_raises(Oidc::AuthenticationError) { verifier.verify(token, nonce) }
+    end
+  end
+
+  test 'rejects a wrong authorized party for multiple audiences' do
+    payload = valid_payload.merge('aud' => ['foreman', 'another-client'], 'azp' => 'another-client')
+    token = JWT.encode(payload, key.keypair, 'RS256', 'kid' => key.kid)
+
+    assert_raises(Oidc::AuthenticationError) { verifier.verify(token, nonce) }
+  end
+
+  test 'rejects algorithms outside the configured allowlist' do
+    token = JWT.encode(valid_payload, key.keypair, 'RS512', 'kid' => key.kid)
+
+    assert_raises(Oidc::AuthenticationError) { verifier.verify(token, nonce) }
+  end
+
+  test 'verifies an access token hash when present' do
+    access_token = 'access-token'
+    digest = OpenSSL::Digest::SHA256.digest(access_token)
+    at_hash = Base64.urlsafe_encode64(digest.first(digest.bytesize / 2), :padding => false)
+    token = JWT.encode(valid_payload.merge('at_hash' => at_hash), key.keypair, 'RS256', 'kid' => key.kid)
+
+    assert_equal at_hash, verifier.verify(token, nonce, access_token)['at_hash']
+    assert_raises(Oidc::AuthenticationError) { verifier.verify(token, nonce, 'wrong-token') }
+  end
+
+  private
+
+  def valid_payload
+    {
+      'sub' => 'subject-1',
+      'iss' => auth_source.oidc_issuer,
+      'aud' => auth_source.oidc_client_id,
+      'exp' => 5.minutes.from_now.to_i,
+      'iat' => Time.now.utc.to_i,
+      'nonce' => nonce,
+    }
+  end
+end

--- a/test/services/oidc/user_resolver_test.rb
+++ b/test/services/oidc/user_resolver_test.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+
+class Oidc::UserResolverTest < ActiveSupport::TestCase
+  let(:auth_source) { FactoryBot.create(:auth_source_oidc, :onthefly_register => true) }
+  let(:authentication) do
+    Oidc::Authenticator::Result.new(
+      :claims => {
+        'preferred_username' => 'keycloak-user',
+        'given_name' => 'Keycloak',
+        'family_name' => 'User',
+        'email' => 'keycloak@example.test',
+      },
+      :subject => 'subject-1',
+      :email => 'keycloak@example.test',
+      :email_verified => true,
+      :groups => []
+    )
+  end
+
+  test 'provisions a user and a separate provider identity' do
+    result = Oidc::UserResolver.new(auth_source, authentication).resolve
+
+    assert result.created
+    assert_equal 'keycloak-user', result.user.login
+    assert_equal auth_source, result.user.auth_source
+    assert_equal 'subject-1', result.identity.subject
+  end
+
+  test 'resolves a returning identity without creating another user' do
+    first = Oidc::UserResolver.new(auth_source, authentication).resolve
+    User.current = nil
+
+    assert_no_difference('User.unscoped.count') do
+      second = Oidc::UserResolver.new(auth_source, authentication).resolve
+      assert_equal first.user, second.user
+      refute second.created
+    end
+  end
+
+  test 'links an existing account only with verified email when enabled' do
+    existing = FactoryBot.create(:user, :mail => authentication.email)
+    auth_source.update!(:oidc_link_verified_email => true, :onthefly_register => false)
+
+    result = Oidc::UserResolver.new(auth_source, authentication).resolve
+
+    assert_equal existing, result.user
+    assert_equal existing.auth_source, result.user.auth_source
+  end
+
+  test 'does not link an existing account with an unverified email' do
+    FactoryBot.create(:user, :mail => authentication.email)
+    auth_source.update!(:oidc_link_verified_email => true, :onthefly_register => false)
+    authentication.email_verified = false
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::UserResolver.new(auth_source, authentication).resolve
+    end
+  end
+
+  test 'rejects ambiguous verified email links' do
+    2.times { FactoryBot.create(:user, :mail => authentication.email) }
+    auth_source.update!(:oidc_link_verified_email => true, :onthefly_register => false)
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::UserResolver.new(auth_source, authentication).resolve
+    end
+  end
+
+  test 'never links hidden system users by email' do
+    hidden_user = users(:anonymous)
+    hidden_user.update_column(:mail, authentication.email)
+    auth_source.update!(:oidc_link_verified_email => true, :onthefly_register => false)
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::UserResolver.new(auth_source, authentication).resolve
+    end
+  end
+
+  test 'rejects a disabled linked account' do
+    user = FactoryBot.create(:user, :disabled => true)
+    FactoryBot.create(:oidc_identity, :auth_source => auth_source, :user => user,
+      :subject => authentication.subject)
+
+    assert_raises(Oidc::AuthenticationError) do
+      Oidc::UserResolver.new(auth_source, authentication).resolve
+    end
+  end
+
+  test 'avoids login collisions without linking by login' do
+    FactoryBot.create(:user, :login => 'keycloak-user')
+
+    result = Oidc::UserResolver.new(auth_source, authentication).resolve
+
+    assert_match(/\Akeycloak-user-[0-9a-f]{8}\z/, result.user.login)
+  end
+end

--- a/test/unit/foreman/access_permissions_test.rb
+++ b/test/unit/foreman/access_permissions_test.rb
@@ -13,7 +13,8 @@ class AccessPermissionsTest < ActiveSupport::TestCase
   include AccessPermissionsTestBase
 
   MAY_SKIP_REQUIRE_LOGIN = [
-    "users/login", "users/logout", "users/extlogin", "users/extlogout", "home/status", "notices/destroy",
+    "users/login", "users/logout", "users/extlogin", "users/extlogout",
+    "oidc_authentications/start", "oidc_authentications/callback", "home/status", "notices/destroy",
 
     # unattended built and failed action is not for interactive use
     "unattended/built", "unattended/failed",

--- a/test/unit/sso/configured_openid_connect_test.rb
+++ b/test/unit/sso/configured_openid_connect_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class ConfiguredOpenidConnectTest < ActiveSupport::TestCase
+  let(:auth_source) do
+    FactoryBot.create(:auth_source_oidc,
+      :oidc_issuer => 'https://idp.example.test',
+      :oidc_allow_api_bearer => true,
+      :oidc_api_audiences => 'foreman-api')
+  end
+  let(:user) { FactoryBot.create(:user) }
+  let(:payload) do
+    {
+      'sub' => 'subject-1',
+      'iss' => auth_source.oidc_issuer,
+      'aud' => 'foreman-api',
+      'exp' => 5.minutes.from_now.to_i,
+      'iat' => Time.now.utc.to_i,
+    }
+  end
+  let(:token) { JWT.encode(payload, nil, 'none') }
+  let(:controller) { api_controller(token) }
+  let(:sso) { SSO::ConfiguredOpenidConnect.new(controller) }
+
+  setup do
+    FactoryBot.create(:oidc_identity, :auth_source => auth_source, :user => user, :subject => payload['sub'])
+  end
+
+  test 'is available for an enabled provider selected by issuer' do
+    assert sso.available?
+  end
+
+  test 'is not available unless API bearer authentication is enabled' do
+    auth_source.update!(:oidc_allow_api_bearer => false)
+
+    refute sso.available?
+  end
+
+  test 'rejects ambiguous provider selection' do
+    FactoryBot.create(:auth_source_oidc,
+      :oidc_issuer => auth_source.oidc_issuer,
+      :oidc_api_audiences => 'foreman-api',
+      :oidc_allow_api_bearer => true)
+
+    refute sso.available?
+  end
+
+  test 'authenticates only an already linked identity' do
+    Oidc::AccessTokenVerifier.any_instance.stubs(:verify).returns(payload)
+
+    assert sso.available?
+    assert sso.authenticated?
+    assert_equal user, sso.current_user
+  end
+
+  test 'rejects a disabled linked user' do
+    user.update!(:disabled => true)
+    Oidc::AccessTokenVerifier.any_instance.stubs(:verify).returns(payload)
+
+    assert sso.available?
+    refute sso.authenticated?
+  end
+
+  test 'does not provision or link users from API tokens' do
+    auth_source.oidc_identities.destroy_all
+    Oidc::AccessTokenVerifier.any_instance.stubs(:verify).returns(payload)
+
+    assert sso.available?
+    assert_no_difference('User.unscoped.count') do
+      refute sso.authenticated?
+    end
+  end
+
+  private
+
+  def api_controller(bearer_token)
+    request = Struct.new(:authorization).new("Bearer #{bearer_token}")
+    Struct.new(:request) do
+      def api_request?
+        true
+      end
+    end.new(request)
+  end
+end

--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.fixtures.js
@@ -2,10 +2,12 @@ export const alerts = { error: 'some-error' };
 export const caption = 'some caption';
 export const logoSrc = '/some-logo';
 export const token = 'some token';
+export const oidcProviders = [{ name: 'Keycloak', url: '/users/oidc/keycloak' }];
 
 export const props = {
   alerts,
   caption,
   logoSrc,
+  oidcProviders,
   token,
 };

--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js
@@ -12,11 +12,11 @@ import {
   FormAlert,
 } from '@patternfly/react-core';
 
-import { translate as __ } from '../../common/I18n';
+import { sprintf, translate as __ } from '../../common/I18n';
 import { adjustAlerts, defaultFormProps } from './helpers';
 import './LoginPage.scss';
 
-const LoginPage = ({ alerts, caption, logoSrc, token }) => {
+const LoginPage = ({ alerts, caption, logoSrc, oidcProviders, token }) => {
   const { modifiedAlerts, submitErrors } = adjustAlerts(alerts);
 
   const [username, setUsername] = useState('');
@@ -114,6 +114,30 @@ const LoginPage = ({ alerts, caption, logoSrc, token }) => {
     </Form>
   );
 
+  const oidcLogin = oidcProviders.length > 0 && (
+    <>
+      <hr />
+      {oidcProviders.map(provider => (
+        <form
+          className="external-login-form"
+          key={provider.url}
+          action={provider.url}
+          method="post"
+        >
+          <input name="authenticity_token" type="hidden" value={token} />
+          <Button
+            ouiaId={`external-login-${provider.name}`}
+            type="submit"
+            isBlock
+            variant="secondary"
+          >
+            {sprintf(__('Log in with %s'), provider.name)}
+          </Button>
+        </form>
+      ))}
+    </>
+  );
+
   return (
     <div id="login-page">
       <PF5LoginPage
@@ -124,6 +148,7 @@ const LoginPage = ({ alerts, caption, logoSrc, token }) => {
         textContent={caption}
       >
         {loginForm}
+        {oidcLogin}
       </PF5LoginPage>
     </div>
   );
@@ -138,6 +163,12 @@ LoginPage.propTypes = {
   backgroundUrl: PropTypes.string,
   caption: PropTypes.string,
   logoSrc: PropTypes.string,
+  oidcProviders: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    })
+  ),
   token: PropTypes.string.isRequired,
 };
 
@@ -146,6 +177,7 @@ LoginPage.defaultProps = {
   backgroundUrl: null,
   caption: null,
   logoSrc: null,
+  oidcProviders: [],
 };
 
 export default LoginPage;

--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
@@ -11,6 +11,10 @@ $background_image: url('../LoginPage/background.svg');
     background-size: contain;
     background-repeat: repeat-y;
   }
+
+  .external-login-form + .external-login-form {
+    margin-top: 0.5rem;
+  }
 }
 
 #login-page .pf-v5-c-login__footer p {

--- a/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/LoginPage.test.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/LoginPage.test.js
@@ -59,4 +59,17 @@ describe('LoginPage', () => {
 
     expect(submitButton).toBeEnabled();
   });
+
+  it('renders configured OpenID Connect providers', () => {
+    renderLoginPage({
+      alerts: null,
+      oidcProviders: [{ name: 'Keycloak', url: '/users/oidc/keycloak' }],
+    });
+
+    const button = screen.getByRole('button', { name: 'Log in with Keycloak' });
+    expect(button).toBeInTheDocument();
+    expect(button.closest('form')).toHaveAttribute('action', '/users/oidc/keycloak');
+    expect(button.closest('form')).toHaveAttribute('method', 'post');
+    expect(button.closest('form').elements.authenticity_token).toHaveValue(token);
+  });
 });


### PR DESCRIPTION
## What this changes

This adds native multi-provider OpenID Connect authentication to Foreman without requiring Apache/mod_auth_openidc.

OIDC providers are managed as authentication sources and can be added or changed without restarting Foreman. The implementation includes:

* Authorization Code flow with state, nonce and PKCE S256;
* discovery or manually configured provider endpoints;
* confidential and public clients with encrypted client secrets and custom CA support;
* strict issuer, audience, authorized-party, time, nonce, signature and at_hash validation;
* separate provider identities keyed by provider and stable subject;
* safe opt-in linking through a unique verified email address;
* automatic provisioning, taxonomy assignment and user attribute updates;
* group synchronization through existing external user groups;
* self-service identity linking and administrator management;
* RP-initiated logout;
* provider management and connection testing in the UI and API;
* optional API bearer authentication for pre-linked identities with a dedicated API audience.

Provider access, refresh and ID tokens are not persisted. Foreman keeps its own authenticated session after the callback.

## Compatibility

The implementation uses Foreman's existing rest-client and jwt dependencies. It does not add another OIDC client gem or change Faraday constraints, so the shared Foreman and Katello Bundler graph remains compatible.

The existing global OIDC bearer-token validator and Apache SSO integration remain available. The developer documentation includes Keycloak configuration and a migration path from Apache-based OIDC.

## Testing

* LoginPage Jest tests: 5 passing
* ESLint for the changed LoginPage files
* Stylelint for the changed stylesheet
* Ruby syntax checks for the changed Ruby and RABL files supported by the local Ruby version
* staged diff and whitespace checks

The complete Ruby test matrix will run in CI because this local checkout does not have the full Foreman bundle installed.

Related to #28345 and supersedes the incomplete proof of concept in #10797.

Assisted-By: Codex 5.6 Sol High
