### PR TITLE
Fixes #39720 - add kickstart-network-no-activate host parameter

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -54,6 +54,7 @@ description: |
   - use_graphical_installer: boolean (default=false)
   - enable-remote-execution-pull: boolean (default=false)
   - additional-packages: string (default=undef)
+  - kickstart-network-no-activate: boolean (default=false)
   - use-redhat-register-snippet: boolean (default=false)
 
   This template inherits the following parameters from included snippets:

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
@@ -14,6 +14,10 @@ description: |
 <%
 network_options = []
 nameservers = []
+
+# Leave an already-working installer NIC alone (e.g. LACP bond from boot options).
+# https://projects.theforeman.org/issues/39499
+network_options.push("--no-activate") if host_param_true?('kickstart-network-no-activate')
 subnet4 = @iface.subnet
 subnet6 = @iface.subnet6
 


### PR DESCRIPTION
Fixes #39720

Satellite: https://redhat.atlassian.net/browse/SAT-49421
Installer bug (not fixed here): https://redhat.atlassian.net/browse/RHELPLAN-140012

## What
Add optional host/OS/Host group parameter `kickstart-network-no-activate`.
When true, `kickstart_network_interface` prefixes the Kickstart `network`
command with `--no-activate`. Default is false, so existing renders are
unchanged.

## Why
RHEL 9+ LACP bonds brought up in initramfs get reactivated by Anaconda
when Kickstart applies `network`, which breaks early `rhsm`. The documented
workaround is `--no-activate`. Users currently have to clone Kickstart
default (or this snippet) to use it.

## How to test
1. Provision with stock Kickstart default, parameter unset → `network` line
   has no `--no-activate` (same as today).
2. Set OS or Host group parameter `kickstart-network-no-activate=true` →
   rendered KS contains `network --no-activate ...`.
3. On an LACP+rhsm host, installation/registration succeeds without cloning
   Kickstart default.