### PR TITLE
Fixes #39736 - Render response descriptions in apidoc HTML

### DIFF
--- a/app/views/apipie/apipies/_method_detail.erb
+++ b/app/views/apipie/apipies/_method_detail.erb
@@ -32,6 +32,30 @@
   </table>
 <% end %>
 
+<% unless method[:returns].blank? %>
+  <%= heading(t('apipie.returns'), h_level) %>
+  <% method[:returns].each do |item| %>
+    <%= heading("#{t('apipie.code')}: #{item[:code]}", h_level + 1) %>
+    <% if item[:description] %>
+      <%= heading("#{t('apipie.description')}:", h_level + 2) %>
+      <p><%= item[:description] %></p>
+    <% end %>
+    <table class='table'>
+      <thead>
+        <tr>
+          <th><%= t('apipie.param_name') %></th>
+          <th><%= t('apipie.description') %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(:partial => "params", :locals => {:params => item[:returns_object]}) %>
+      </tbody>
+    </table>
+
+    <%= render(:partial => "headers", :locals => {:headers => item[:headers], :h_level => h_level + 2 }) %>
+  <% end %>
+<% end %>
+
 <% unless method[:metadata].blank? %>
   <%= render(:partial => "metadata", :locals => {:meta => method[:metadata], :h_level => h_level}) %>
 <% end %>

--- a/test/integration/apipie_test.rb
+++ b/test/integration/apipie_test.rb
@@ -10,4 +10,13 @@ class ApipieIntegrationTest < ActionDispatch::IntegrationTest
     get "/templates_doc"
     assert_equal 200, status
   end
+
+  test "method page renders declared return values" do
+    get "/apidoc/v2/settings/show.en.html"
+    assert_equal 200, status
+    assert_includes response.body, 'Returns'
+    # full_name is documented only in the returns group of settings#show,
+    # so its presence proves the returns table rendered
+    assert_includes response.body, 'full_name'
+  end
 end


### PR DESCRIPTION
Port the returns block from apipie's _method_detail template into the copied override, which predates apipie's response documentation support.

This could also be solved by removing `_method_detail.erb` so we aren't shadowing apipie's version, and add something like `<% h_level = local_assigns.fetch(:h_level, 4) %>` to `_metadata.erb`, but this would result in slight tweaks to ordering of the blocks on some pages and formatting (particularly ones with search field tables), so I went this way for the minimal amount of user-facing change. But if you'd prefer the latter, let me know and I can put that one up instead.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
