### PR TITLE
Allow puma 7.2.x and 8.x in the service bundler group

### DIFF
--- a/bundler.d/service.rb
+++ b/bundler.d/service.rb
@@ -1,4 +1,4 @@
-gem 'puma', '>= 5.1', '< 7', groups: [:test, :service], require: false
+gem 'puma', '>= 5.1', '< 9', groups: [:test, :service], require: false
 group :service do
   # Puma has a soft dependency on this
   gem 'sd_notify', '~> 0.1.0'


### PR DESCRIPTION
## Problem

puma >= 5.5 and < 7.2.1 is affected by the PROXY protocol v1 vulnerabilities CVE-2026-47736 and CVE-2026-47737 (crafted PROXY protocol headers can cause request injection on keep-alive connections and DoS). The current constraint `>= 5.1, '< 7'` keeps every affected release in the allowed range and blocks the fixed ones (the first patched release above 6.6.1 is 7.2.1).

## Fix

Raise the ceiling of the constraint in `bundler.d/service.rb` from `'< 7'` to `'< 9'` while keeping the `'>= 5.1'` lower bound, so packaging (RPMs ship puma 6.6.1 today) can advance on its own schedule while source builds resolve to the patched releases (puma 7.2.1+ or 8.x).

## Verification

Verified against Foreman 5.0.0-rc2 sources on a CentOS Stream 10 container with puma 7.2.1 and nokogiri 1.19.4: the application boots, migrates, seeds, and serves - `users/login` returns 200 and `/api/v2/ping` returns 200. The full source-built image is exercised continuously in our CI (built, smoke-tested and scanned on every commit).

Note: `concurrent-ruby` cannot follow in the same move: dynflow pins `~> 1.1.3` and concurrent-ruby-edge `~> 0.6.0` (see the companion issue on Dynflow/dynflow proposing that relaxation).
