### PR TITLE
Fixes #39739 - require applied errata inputs

### DIFF
--- a/app/views/unattended/report_templates/host_-_applied_errata.erb
+++ b/app/views/unattended/report_templates/host_-_applied_errata.erb
@@ -3,7 +3,7 @@ name: Host - Applied Errata
 snippet: false
 template_inputs:
 - name: Filter Errata Type
-  required: false
+  required: true
   input_type: user
   description: Filter only errata of a given type. If you select all, errata are not
     filtered by type.
@@ -19,7 +19,7 @@ template_inputs:
   value_type: search
   resource_type: Host
 - name: Include Last Reboot
-  required: false
+  required: true
   input_type: user
   description: Last reboot information is based on configuration management facts,
     such as uptime reported by Puppet or Ansible. The computation might be performance
@@ -28,7 +28,7 @@ template_inputs:
   default: "no"
   advanced: false
 - name: Status
-  required: false
+  required: true
   input_type: user
   description: Limit the search based on the application result.
   options: "all\r\nsuccess\r\nwarning\r\nerror\r\ncancelled"

--- a/test/models/report_composer_test.rb
+++ b/test/models/report_composer_test.rb
@@ -31,6 +31,33 @@ class ReportComposerTest < ActiveSupport::TestCase
     assert_includes invalid.errors.full_messages, "Input #{@template_input.name}: Value can't be blank"
   end
 
+  test 'option list inputs use defaults when no value is submitted' do
+    FactoryBot.create(:template_input,
+      :template => @report_template,
+      :name => 'Filter Errata Type',
+      :required => true,
+      :options => "all\r\nsecurity\r\nbugfix",
+      :default => 'all')
+    FactoryBot.create(:template_input,
+      :template => @report_template,
+      :name => 'Include Last Reboot',
+      :required => true,
+      :options => "yes\r\nno",
+      :default => 'no')
+    FactoryBot.create(:template_input,
+      :template => @report_template,
+      :name => 'Status',
+      :required => true,
+      :options => "all\r\nsuccess\r\nerror",
+      :default => 'all')
+
+    composer = ReportComposer.new(:template_id => @report_template.id, :input_values => {})
+    assert composer.valid?, composer.errors.full_messages.to_s
+    assert_equal 'all', composer.template_input_values['Filter Errata Type']
+    assert_equal 'no', composer.template_input_values['Include Last Reboot']
+    assert_equal 'all', composer.template_input_values['Status']
+  end
+
   test 'can be created from UI params' do
     params = { :id => @report_template.id, :report_template_report => { :input_values => { @template_input.id.to_s => { 'value' => 'hello' } } } }
     params.expects(:permit!).returns(params)

--- a/test/unit/report_templates/host_applied_errata_test.rb
+++ b/test/unit/report_templates/host_applied_errata_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class HostAppliedErrataTemplateTest < ActiveSupport::TestCase
+  def template_path
+    Rails.root.join('app/views/unattended/report_templates/host_-_applied_errata.erb')
+  end
+
+  def inputs_by_name
+    metadata = Template.parse_metadata(File.read(template_path))
+    metadata['template_inputs'].index_by { |input| input['name'] }
+  end
+
+  test 'closed option inputs are required and have defaults' do
+    expected = {
+      'Filter Errata Type' => 'all',
+      'Include Last Reboot' => 'no',
+      'Status' => 'all',
+    }
+
+    expected.each do |name, default|
+      input = inputs_by_name[name]
+      assert input, "expected template input #{name}"
+      assert input['required'], "#{name} should be required so the generate form shows an asterisk"
+      assert_equal default, input['default'], "#{name} should default to #{default}"
+      options = input['options'].to_s.split(/\r?\n/).map(&:strip)
+      assert_includes options, default, "#{name} default must be one of the listed options"
+    end
+  end
+
+  test 'optional search and date inputs remain optional' do
+    ['Hosts filter', 'Since', 'Up to'].each do |name|
+      input = inputs_by_name[name]
+      assert input, "expected template input #{name}"
+      refute input['required'], "#{name} should remain optional"
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/39739

Host - Applied Errata option inputs were not marked required, so the
generate form showed no asterisk. Blank values fail inclusion
validation ("is not included in the list"). Mark the closed-list
inputs required. Existing defaults still pre-fill the fields.

Test plan:
- Monitor -> Reports -> Report Templates -> Host - Applied Errata -> Generate
- Filter Errata Type, Include Last Reboot, and Status show an asterisk and defaults
- Generate with no extra input succeeds