### PR TITLE
Fixes #39740 - Close popovers on tab change

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -35,6 +35,13 @@ $(document).on('click', 'a[disabled="disabled"]', function(event) {
   return handleDisabledClick(event, this);
 });
 
+// Popovers use container: 'body' (see layout_helper#popover), so they stay
+// visible after the triggering tab is hidden unless closed explicitly.
+$(document).on('hide.bs.tab', 'a[data-toggle="tab"]', function() {
+  $('a[rel="popover"]').popover('destroy');
+  $('.popover').remove();
+});
+
 const removeSelect2TitlesTooltips = function() {
   // select2 tooltips dont update and dont close properly
   $('.select2-selection span').attr('title', '');

--- a/test/integration/smart_proxy_js_test.rb
+++ b/test/integration/smart_proxy_js_test.rb
@@ -46,6 +46,29 @@ class SmartProxyJSTest < IntegrationTestWithJavascript
     assert page.has_content? "Version"
   end
 
+  test "dismisses popovers when switching tabs" do
+    proxy = smart_proxies(:one)
+    visit smart_proxy_path(proxy)
+    click_link "Services"
+    assert page.has_selector?('h3', :text => "DHCP")
+
+    page.execute_script(<<~JS)
+      var trigger = document.createElement('a');
+      trigger.setAttribute('rel', 'popover');
+      trigger.setAttribute('href', '#');
+      trigger.setAttribute('data-content', 'Spool error help');
+      trigger.setAttribute('data-container', 'body');
+      trigger.setAttribute('data-trigger', 'focus');
+      trigger.textContent = 'info';
+      document.getElementById('services').appendChild(trigger);
+      $(trigger).popover('show');
+    JS
+
+    assert page.has_selector?('.popover', visible: true)
+    within('#proxy-tab') { click_link 'Overview' }
+    assert page.has_no_selector?('.popover', visible: true)
+  end
+
   describe 'pagelets on show page' do
     include PageletsIsolation
 


### PR DESCRIPTION
Fixes [Bug #39740](https://projects.theforeman.org/issues/39740)
Popovers appended to `body` stayed visible after switching Bootstrap tabs (Smart Proxy Services → OpenSCAP Spool errors info icon). They are now destroyed on `hide.bs.tab`.
SAT-37278
## Test plan
- [ ] Smart Proxies → proxy with OpenSCAP → Services → click Spool errors info icon
- [ ] Switch to Logs or Overview — popover disappears
- [ ] Return to Services and open the popover again — it still works