### PR TITLE
Fixes #34810 - Add report template descriptions

### DIFF
--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -20,6 +20,7 @@ class ReportTemplate < Template
   include Taxonomix
   scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name,    :complete_value => true, :default_order => true
+  scoped_search :on => :description, :complete_value => false
   scoped_search :on => :locked,  :complete_value => {:true => true, :false => false}
   scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}
   scoped_search :on => :template

--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -4,11 +4,12 @@
 
 <%= form_for @composer, as: :report_template_report, url: schedule_report_report_template_path(@template) do |f| %>
 
+  <% generate_text = content_tag(:p, _('This will generate a report %s. Based on its definition, it can take a long time to process.') % @template.name)
+     generate_text += content_tag(:div, simple_format(@template.description), class: 'report-template-description') if @template.description.present?
+  %>
   <%= alert(:class => 'alert-info',
             :header => _('Generating a report'),
-            :text => ('<p>' +
-                (_('This will generate a report %s. Based on its definition, it can take a long time to process.') % h(@template.name)) +
-                '</p>').html_safe) %>
+            :text => generate_text) %>
 
   <%= datetime_local_f f, :generate_at,
       label: _('Generate at'),

--- a/app/views/report_templates/index.html.erb
+++ b/app/views/report_templates/index.html.erb
@@ -8,6 +8,7 @@
   <thead>
     <tr>
       <th class="col-md-3"><%= sort :name, :as => s_("ReportTemplate|Name") %></th>
+      <th class="col-md-5"><%= sort :description, :as => s_("ReportTemplate|Description") %></th>
       <th class="col-md-1"><%= sort :snippet, :as => s_("ReportTemplate|Snippet") %></th>
       <th class="col-md-1"><%= sort :locked, :as => s_("ReportTemplate|Locked"), :default => "DESC" %></th>
       <th class="col-md-1"><%= _('Actions') %></th>
@@ -21,6 +22,7 @@
                                          merge(:auth_object => report_template, :authorizer => authorizer,
                                          :permission => 'edit_report_templates') %>
         </td>
+        <td class="ellipsis"><%= trunc_with_tooltip(report_template.description.to_s.squish, 80) if report_template.description.present? %></td>
         <td align='center'><%= checked_icon report_template.snippet %></td>
         <td align='center'><%= locked_icon report_template.locked?, _("This template is locked for editing.") %>
         </td>

--- a/app/views/unattended/report_templates/ansible_-_ansible_inventory.erb
+++ b/app/views/unattended/report_templates/ansible_-_ansible_inventory.erb
@@ -1,6 +1,8 @@
 <%#
 name: Ansible - Ansible Inventory
-description: This template has a special meaning and should not be renamed.
+description: |
+  Generates an Ansible inventory of hosts with optional groups and variables.
+  This template has a special meaning and should not be renamed.
 snippet: false
 template_inputs:
 - name: Organization

--- a/app/views/unattended/report_templates/host_-_all_installed_packages.erb
+++ b/app/views/unattended/report_templates/host_-_all_installed_packages.erb
@@ -1,5 +1,8 @@
 <%#
 name: Host - All Installed Packages
+description: |
+  Lists all packages installed on hosts, including name, NVRA, and NVREA.
+  This report can be large in environments with many hosts.
 snippet: false
 template_inputs:
 - name: Hosts filter

--- a/app/views/unattended/report_templates/host_-_applied_errata.erb
+++ b/app/views/unattended/report_templates/host_-_applied_errata.erb
@@ -1,5 +1,10 @@
 <%#
 name: Host - Applied Errata
+description: |
+  Lists errata that were applied to hosts through this Foreman instance,
+  for example via remote execution. Errata applied outside of Foreman are
+  not included, so the report can be empty even when hosts were patched
+  by other means.
 snippet: false
 template_inputs:
 - name: Filter Errata Type

--- a/app/views/unattended/report_templates/host_-_available_errata.erb
+++ b/app/views/unattended/report_templates/host_-_available_errata.erb
@@ -1,5 +1,9 @@
 <%#
 name: Host - Available Errata
+description: |
+  Lists errata applicable or installable on hosts. Applicable includes all
+  matching errata. Installable limits the report to errata available in the
+  host's content view environment and therefore installable from Foreman.
 snippet: false
 template_inputs:
 - name: Hosts filter

--- a/app/views/unattended/report_templates/host_-_compare_content_hosts_packages.erb
+++ b/app/views/unattended/report_templates/host_-_compare_content_hosts_packages.erb
@@ -1,5 +1,8 @@
 <%#
 name: Host - compare content hosts packages
+description: |
+  Compares installed packages between two hosts and reports whether each
+  package is present on one host only, or which host has a newer version.
 snippet: false
 template_inputs:
 - name: Host 1

--- a/app/views/unattended/report_templates/host_-_enabled_repositories.erb
+++ b/app/views/unattended/report_templates/host_-_enabled_repositories.erb
@@ -1,5 +1,8 @@
 <%#
 name: Host - Enabled Repositories
+description: |
+  Lists repositories enabled on each host and the package count for
+  each repository.
 snippet: false
 model: ReportTemplate
 require:

--- a/app/views/unattended/report_templates/host_-_installed_products.erb
+++ b/app/views/unattended/report_templates/host_-_installed_products.erb
@@ -1,5 +1,8 @@
 <%#
 name: Host - Installed Products
+description: |
+  Lists products installed on hosts together with organization, content
+  view environments, hardware, and optional cloud billing metadata.
 snippet: false
 model: ReportTemplate
 template_inputs:

--- a/app/views/unattended/report_templates/host_-_registered_content_hosts.erb
+++ b/app/views/unattended/report_templates/host_-_registered_content_hosts.erb
@@ -1,5 +1,10 @@
 <%#
 name: Host - Registered Content Hosts
+description: |
+  Lists registered content hosts with operating system, owner, kernel, and
+  errata IDs. Choose Applicable or Installable errata based on whether you
+  need all matching errata or only those available in the host's content
+  view environment.
 snippet: false
 template_inputs:
 - name: Hosts filter

--- a/app/views/unattended/report_templates/host_-_statuses.erb
+++ b/app/views/unattended/report_templates/host_-_statuses.erb
@@ -1,5 +1,8 @@
 <%#
 name: Host - Statuses
+description: |
+  Lists hosts with their global and individual statuses, either as shown
+  in the web UI or as numeric values for machine processing.
 snippet: false
 template_inputs:
 - name: hosts

--- a/app/views/unattended/report_templates/job_-_invocation_report.erb
+++ b/app/views/unattended/report_templates/job_-_invocation_report.erb
@@ -1,5 +1,9 @@
 <%#
 name: Job - Invocation Report
+description: |
+  Lists results of a remote execution job invocation, including host
+  stdout, stderr, debug output, result, and finish time. Requires the
+  job invocation ID.
 snippet: false
 template_inputs:
 - name: job_id

--- a/app/views/unattended/report_templates/subscription_-_general_report.erb
+++ b/app/views/unattended/report_templates/subscription_-_general_report.erb
@@ -1,5 +1,9 @@
 <%#
 name: Subscription - General Report
+description: |
+  Lists subscription pools including quantity, SKU, contract number,
+  start and end dates, remaining days, and product host count.
+  Filter by search query or upcoming expiration.
 snippet: false
 template_inputs:
 - name: Subscriptions filter

--- a/app/views/unattended/report_templates/user_-_registered_users.erb
+++ b/app/views/unattended/report_templates/user_-_registered_users.erb
@@ -1,6 +1,8 @@
 <%#
 name: User - Registered Users
-description: Report of registered users
+description: |
+  Lists registered users, including login, name, email, last login, and
+  authentication source.
 snippet: false
 template_inputs:
 - name: Users filter

--- a/test/controllers/report_templates_controller_test.rb
+++ b/test/controllers/report_templates_controller_test.rb
@@ -13,6 +13,13 @@ class ReportTemplatesControllerTest < ActionController::TestCase
     assert_template 'index'
   end
 
+  test 'index shows report template description' do
+    @report_template.update!(description: 'Lists hosts that have not checked in recently')
+    get :index, session: set_session_user
+    assert_response :success
+    assert_includes @response.body, 'Lists hosts that have not checked in recently'
+  end
+
   test 'new' do
     get :new, session: set_session_user
     assert_template 'new'
@@ -139,6 +146,14 @@ class ReportTemplatesControllerTest < ActionController::TestCase
   test "generate" do
     get :generate, params: { :id => @report_template.to_param }, session: set_session_user
     assert_response :success
+  end
+
+  test "generate shows report template description" do
+    @report_template.update!(description: "Lists inactive hosts.\nCheck-in is based on subscription manager.")
+    get :generate, params: { :id => @report_template.to_param }, session: set_session_user
+    assert_response :success
+    assert_select '.report-template-description', /Lists inactive hosts/
+    assert_includes @response.body, 'Check-in is based on subscription manager.'
   end
 
   describe '#schedule_report' do

--- a/test/models/report_template_test.rb
+++ b/test/models/report_template_test.rb
@@ -22,4 +22,11 @@ class ReportTemplateTest < ActiveSupport::TestCase
     EOT
     assert report_with_macro.supports_format_selection?
   end
+
+  test 'shipped report templates include a description' do
+    Dir[Rails.root.join('app/views/unattended/report_templates/*.erb')].each do |path|
+      metadata = Template.parse_metadata(File.read(path))
+      assert metadata['description'].present?, "#{File.basename(path)} is missing a description"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add descriptions to shipped report templates (same approach as provisioning templates).
- Show the description on the Report Templates index and on the Generate a report form.

This implements [SAT-23982](https://redhat.atlassian.net/browse/SAT-23982) / [Foreman #34810](https://projects.theforeman.org/issues/34810): users can see what each report does without opening the editor.

## Test plan
- [ ] Monitor → Report Templates: each default template has a Description column
- [ ] Generate a report: the description appears in the info alert above the form
- [ ] Templates without a description still generate normally
- [ ] Host - Applied Errata description notes that only errata applied through Foreman are included


Made with [Cursor](https://cursor.com)