### PR TITLE
Enable Bootsnap in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ FOREMAN_GEMFILE = __FILE__ unless defined? FOREMAN_GEMFILE
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.0.3'
+gem 'bootsnap', require: false
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
 gem 'audited', '~> 5.0', '!= 5.1.0'
 gem 'will_paginate', '~> 3.3'

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -23,6 +23,5 @@ group :development do
   gem 'spring', '4.2.1'
   gem 'benchmark-ips', '>= 2.8.2'
   gem 'foreman'
-  gem('bootsnap', :require => false)
   gem 'graphiql-rails', '~> 1.7'
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,7 +3,8 @@ require 'rubygems'
 unless File.exist?(File.expand_path('../Gemfile.in', __dir__))
   ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
   require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-  # Set up boootsnap in development and test env with Bundler enabled and development/test group
-  early_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
-  require('bootsnap/setup') if %w[development test].include?(early_env) && File.exist?(ENV['BUNDLE_GEMFILE']) && !Gem::Specification.stubs_for("bootsnap").empty?
 end
+
+# Bootsnap is a runtime dependency and should be enabled in every environment.
+# In RPM installations, Gemfile.in is handled by BundlerExt instead of Bundler.
+require('bootsnap/setup') unless Gem::Specification.stubs_for('bootsnap').empty?


### PR DESCRIPTION
#### Summary

Bootsnap was previously declared only in the development group and was only loaded for development and test environments. This prevented production Foreman deployments, including RPM/BundlerExt installations, from using Bootsnap.

See also https://github.com/theforeman/foremanctl/issues/769#issuecomment-5585366352 for related information

Changes:

* Make Bootsnap a default runtime dependency.
* Remove the development-only Bootsnap declaration.
* Load Bootsnap in every environment when the gem is installed, including the RPM `Gemfile.in` path.

#### Test plan

* Build/install the production dependencies and start Foreman with `RAILS_ENV=production`.
* Verify `Bootsnap.cache_dir` points to the configured cache directory.
* Verify an RPM/BundlerExt installation loads `bootsnap/setup` before application initialization.

`bundle check` was attempted locally but could not complete because the checkout is missing required installed gems.

#### Checklist

* [ ] Tests added/updated (if applicable)
* [ ] Documentation updated (if applicable)

