### PR TITLE
Refs #39586 - avoid double encoding for json reports

### DIFF
--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -194,7 +194,6 @@ module Api
             filename += '.gz' unless filename.end_with?('.gz')
             send_data data, type: 'application/gzip', filename: filename
           else
-            data = data.to_json if @composer.mime_type == 'application/json'
             send_data data, type: @composer.mime_type, filename: @composer.report_filename
           end
         end

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -385,8 +385,8 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
       @controller.expects(:load_dynflow_plan).with('JOBID').returns(plan)
     end
 
-    def stub_plan_arguments(gzip: false, user_id: User.current.id, mail_to: nil)
-      composer_params = { 'template_id' => report_template.id, 'input_values' => nil, 'gzip' => gzip, 'send_mail' => !!mail_to, 'mail_to' => mail_to }
+    def stub_plan_arguments(gzip: false, user_id: User.current.id, mail_to: nil, format: nil)
+      composer_params = { 'template_id' => report_template.id, 'input_values' => nil, 'gzip' => gzip, 'send_mail' => !!mail_to, 'mail_to' => mail_to, 'format' => format }
       @controller.stubs(:plan_arguments).returns([composer_params, { 'user_id' => user_id }])
     end
 
@@ -442,6 +442,18 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
         assert_response :success
         assert_equal 'application/gzip', response.media_type
         assert_equal compressed, response.body
+      end
+
+      it 'does not double-encode JSON report data' do
+        stub_plan_arguments(format: 'json')
+        json_string = [{ 'name' => 'host1', 'ip' => '192.168.0.1' }].to_json
+        StoredValue.expects('read').with('JOBID').returns(json_string)
+
+        get :report_data, params: { id: report_template.id, job_id: 'JOBID' }
+        assert_response :success
+        assert_equal 'application/json', response.media_type
+        parsed = JSON.parse(response.body)
+        assert_kind_of Array, parsed, 'Expected response body to parse as an Array, not a String (double-encoded JSON)'
       end
     end
   end


### PR DESCRIPTION
AI assisted pr.
AI summery:
https://github.com/theforeman/foreman/pull/11127 fixed the responseType: 'blob' argument positioning in API.get, so it now correctly reaches axios config instead of being silently ignored as a header.

Before that fix, axios used its default responseType: 'json', which automatically parsed the response body. This inadvertently stripped one layer of JSON encoding, masking a double-encoding bug in the report_data action.

The report_render_json method in Foreman::Renderer::Scope::Report already calls .to_json on the report data, producing a valid JSON string. This string is stored via StoredValue.write and later retrieved in report_data. The line data = data.to_json if @composer.mime_type == 'application/json' then calls .to_json a second time on an already-serialized string, wrapping it in quotes and escaping all inner quotes (e.g. "[{\"Host Name\":\"value\"...}]" instead of [{"Host Name":"value"...}]).

With responseType: 'blob' now working correctly, axios no longer auto-parses the response, so the double-encoding is no longer hidden and results in malformed JSON report downloads.

Removing this line is safe because StoredValue.read already returns the fully serialized output from the renderer — no additional encoding is needed regardless of format.