### PR TITLE
Refs #39657 - generate returns private key as well

### DIFF
--- a/app/services/foreman/provision/ssh_key.rb
+++ b/app/services/foreman/provision/ssh_key.rb
@@ -9,11 +9,9 @@ require 'tmpdir'
 class Foreman::Provision::SshKey
   # Raised when the key cannot be processed (e.g. malformed public key).
   class Error < StandardError; end
+  GeneratedKeyPair = Struct.new(:private_key, :public_key, keyword_init: true)
 
-  # Generates a brand new SSH key pair with ssh-keygen and returns its public
-  # key as an OpenSSH format string, i.e. the value that would be stored on an
-  # SshKey record. The key pair is created in a temporary directory and the
-  # private key is discarded; only the public key is returned.
+  # Generates a brand new SSH key pair with ssh-keygen and returns both keys.
   #
   # This is meant to be used by tests and plugins that need a valid, unique
   # public key without shipping a static fixture.
@@ -25,7 +23,7 @@ class Foreman::Provision::SshKey
   #   bits:    optional key size passed to `ssh-keygen -b`. Ignored by key
   #            types with a fixed size such as ed25519.
   #
-  # Returns the public key String. Raises Error when ssh-keygen fails.
+  # Returns a GeneratedKeyPair. Raises Error when ssh-keygen fails.
   def self.generate(type: nil, comment: '', bits: nil)
     Dir.mktmpdir('foreman-ssh-key') do |dir|
       path = File.join(dir, 'key')
@@ -35,7 +33,7 @@ class Foreman::Provision::SshKey
       _stdout, stderr, status = Open3.capture3(*args)
       raise Error, "unable to generate SSH key: #{stderr}" unless status.success?
 
-      File.read("#{path}.pub").strip
+      GeneratedKeyPair.new(private_key: File.read(path), public_key: File.read("#{path}.pub").strip)
     end
   end
 

--- a/test/factories/ssh_key.rb
+++ b/test/factories/ssh_key.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     # This is safe to do for as many keys as the tests need: on modern kernels
     # (Linux >= 5.6) /dev/random no longer blocks once the CRNG has been seeded
     # early at boot, so key generation never stalls waiting for entropy.
-    sequence(:key) { |n| Foreman::Provision::SshKey.generate(comment: "foreman#{n}@example.com") }
+    sequence(:key) { |n| Foreman::Provision::SshKey.generate(comment: "foreman#{n}@example.com").public_key }
     association :user, :factory => :user
   end
 end

--- a/test/services/foreman/provision/ssh_key_test.rb
+++ b/test/services/foreman/provision/ssh_key_test.rb
@@ -71,25 +71,33 @@ class Foreman::Provision::SshKeyTest < ActiveSupport::TestCase
   end
 
   context '.generate' do
+    test 'generates a key pair with private and public keys' do
+      pair = Foreman::Provision::SshKey.generate
+
+      assert pair.private_key.start_with?('-----BEGIN')
+      assert pair.public_key.start_with?('ssh-')
+      assert Foreman::Provision::SshKey.new(pair.public_key).valid?
+    end
+
     test 'generates a valid public key' do
-      key = Foreman::Provision::SshKey.generate
-      assert Foreman::Provision::SshKey.new(key).valid?
+      pair = Foreman::Provision::SshKey.generate
+      assert Foreman::Provision::SshKey.new(pair.public_key).valid?
     end
 
     %w[rsa ecdsa ed25519].each do |type|
       test "generates a valid #{type} key" do
-        key = Foreman::Provision::SshKey.generate(:type => type)
-        assert Foreman::Provision::SshKey.new(key).valid?
+        pair = Foreman::Provision::SshKey.generate(:type => type)
+        assert Foreman::Provision::SshKey.new(pair.public_key).valid?
       end
     end
 
     test 'generates a unique key on every call' do
-      refute_equal Foreman::Provision::SshKey.generate, Foreman::Provision::SshKey.generate
+      refute_equal Foreman::Provision::SshKey.generate.public_key, Foreman::Provision::SshKey.generate.public_key
     end
 
     test 'appends the given comment' do
       key = Foreman::Provision::SshKey.generate(:comment => 'foreman@example.com')
-      assert_equal 'foreman@example.com', key.split(' ').last
+      assert_equal 'foreman@example.com', key.public_key.split(' ').last
     end
 
     test 'raises Error on an unknown key type' do


### PR DESCRIPTION
Just a small followup of my previous sshkey work. I introduced new method `generate` that returns public key of a generated SSH, but I somewhat totally forgot about the private sibling. When I started working on integrating this method into plugins, I realized that I do not have it :-)

This refactors the new method to return the whole pair.