### PR TITLE
Refs #39657 - ignore test keys in leak scans

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+description = "SSH key fixtures used by tests"
+paths = [
+	'''test/static_fixtures/ssh_keys/.*''',
+	'''test/static_fixtures/certificates/example\.com\.key''',
+]


### PR DESCRIPTION
SSIA

Red Hat Security alert was sent to me for my own fork.