### PR TITLE
Fixes #39756 - Use string labels for table data-label and aria-label

### DIFF
--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -544,7 +544,8 @@ registerColumns(hostsIndexColumnExtensions);
 Each column extension object must contain the following properties:
 
 * `columnName` - the name of the column, which must match the column name in the API response.
-* `title` - the title of the column to be displayed on screen in the <th> element. Should be translated.
+* `title` - the title of the column to be displayed on screen in the <th> element. Must be a translated string. If you need a custom header node, keep `title` as the string and render the node separately; HTML `data-label` cannot accept a React object.
+* `label` - optional accessible name. Defaults to `title` when `title` is a string.
 * `wrapper` - a function that returns the content (as JSX) to be displayed in the table cell. The function receives the host details as an argument.
 * `weight` - the weight of the column, which determines the order in which columns are displayed. Lower weights are displayed first.
 * `tableName` - the name of the table. Should match the `name` of the user's TablePreference.

--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/helpers.js
@@ -1,4 +1,7 @@
-import { DEFAULT_USER_COLUMNS } from '../PF4/TableIndexPage/Table/helpers';
+import {
+  DEFAULT_USER_COLUMNS,
+  getColumnLabel,
+} from '../PF4/TableIndexPage/Table/helpers';
 
 const getCheckedStateForCategory = (category = { children: [] }) => {
   // return true if all children are checked
@@ -71,7 +74,6 @@ export const categoriesFromFrontendColumnData = ({
       categoryKey,
       tableName,
       columnName,
-      title,
       isRequired,
       isRelevant,
     } = registeredColumns[column];
@@ -93,7 +95,7 @@ export const categoriesFromFrontendColumnData = ({
 
     if (shouldShowColumn) {
       categories[categoryIndex].children.push({
-        name: title,
+        name: getColumnLabel(registeredColumns[column], columnName),
         key: columnName,
         checkProps: {
           checked: isRequired || userColumns.includes(columnName),

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -61,13 +61,13 @@ export const Table = ({
         updateParamsByUrl={!isEmbedded}
       />
     );
+  const [columnNamesKeys, keysToColumnNames] = getColumnHelpers(columns);
   const columnsToSortParams = {};
-  Object.keys(columns).forEach(key => {
+  columnNamesKeys.forEach(key => {
     if (columns[key].isSorted) {
-      columnsToSortParams[columns[key].title] = key;
+      columnsToSortParams[keysToColumnNames[key]] = key;
     }
   });
-  const [columnNamesKeys, keysToColumnNames] = getColumnHelpers(columns);
   const onSort = (_event, index, direction) => {
     setParams({
       ...params,
@@ -75,7 +75,7 @@ export const Table = ({
     });
   };
   const { pfSortParams } = useTableSort({
-    allColumns: Object.keys(columns).map(k => columns[k].title),
+    allColumns: columnNamesKeys.map(k => keysToColumnNames[k]),
     columnsToSortParams,
     onSort,
   });
@@ -152,7 +152,7 @@ export const Table = ({
                 }
                 aria-label={keysToColumnNames[k]}
               >
-                {keysToColumnNames[k]}
+                {columns[k].title}
               </Th>
             ))}
           </Tr>

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
@@ -130,7 +130,9 @@ describe('Table', () => {
       </Provider>
     );
     fireEvent.click(screen.getByLabelText('Kebab toggle'));
-    expect(screen.getByRole('none', {description: 'Delete'})).toHaveClass('pf-m-aria-disabled');
+    expect(screen.getByRole('none', { description: 'Delete' })).toHaveClass(
+      'pf-m-aria-disabled'
+    );
     await act(async () => {
       jest.advanceTimersByTime(1000); // to handle pf4 table actions popover
     });
@@ -244,8 +246,18 @@ describe('Table', () => {
 
   test('uses idColumn prop for React key when provided', () => {
     const customResults = [
-      { custom_id: 'abc-123', name: 'John Doe', email: 'johndoe@example.com', role: 'Admin' },
-      { custom_id: 'xyz-456', name: 'Jane Smith', email: 'janesmith@example.com', role: 'User' },
+      {
+        custom_id: 'abc-123',
+        name: 'John Doe',
+        email: 'johndoe@example.com',
+        role: 'Admin',
+      },
+      {
+        custom_id: 'xyz-456',
+        name: 'Jane Smith',
+        email: 'janesmith@example.com',
+        role: 'User',
+      },
     ];
 
     const { container } = render(
@@ -267,13 +279,24 @@ describe('Table', () => {
     expect(rows).toHaveLength(2);
 
     // Verify rows use custom_id as key
-    expect(rows[0]).toHaveAttribute('data-ouia-component-id', 'table-row-abc-123');
-    expect(rows[1]).toHaveAttribute('data-ouia-component-id', 'table-row-xyz-456');
+    expect(rows[0]).toHaveAttribute(
+      'data-ouia-component-id',
+      'table-row-abc-123'
+    );
+    expect(rows[1]).toHaveAttribute(
+      'data-ouia-component-id',
+      'table-row-xyz-456'
+    );
   });
 
   test('keys remain stable when results are reordered', () => {
     const sortedResults = [
-      { id: 2, name: 'Jane Smith', email: 'janesmith@example.com', role: 'User' },
+      {
+        id: 2,
+        name: 'Jane Smith',
+        email: 'janesmith@example.com',
+        role: 'User',
+      },
       { id: 1, name: 'John Doe', email: 'johndoe@example.com', role: 'Admin' },
     ];
 
@@ -315,5 +338,35 @@ describe('Table', () => {
     rows = container.querySelectorAll('tbody tr');
     expect(rows[0]).toHaveAttribute('data-ouia-component-id', 'table-row-2');
     expect(rows[1]).toHaveAttribute('data-ouia-component-id', 'table-row-1');
+  });
+
+  test('uses a string data-label when column title is a React node', () => {
+    const columnsWithReactTitle = {
+      type: {
+        title: <span title="Image mode / package mode">Type</span>,
+      },
+    };
+    const typeResults = [{ id: 1, type: 'Image mode' }];
+
+    const { container } = render(
+      <Provider store={store}>
+        <Table
+          columns={columnsWithReactTitle}
+          params={{ page: 1, perPage: 10, order: '' }}
+          setParams={setParams}
+          refreshData={refreshData}
+          results={typeResults}
+          url="/users"
+          isPending={false}
+        />
+      </Provider>
+    );
+
+    const typeCell = container.querySelector('td[data-label]');
+    expect(typeCell).toHaveAttribute('data-label', 'Type');
+    expect(typeCell.getAttribute('data-label')).not.toBe('[object Object]');
+    expect(
+      screen.getByRole('columnheader', { name: 'Type' })
+    ).toBeInTheDocument();
   });
 });

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
@@ -21,6 +21,27 @@ export const getPageStats = ({ total, page, perPage }) => {
 };
 
 /**
+ * Accessible string label for a column. Never returns a React node — HTML
+ * attributes like data-label stringify objects as "[object Object]".
+ * @param {Object} column
+ * @param {string} fallbackKey
+ * @returns {string}
+ */
+export const getColumnLabel = (column, fallbackKey) => {
+  if (typeof column?.label === 'string' && column.label.length) {
+    return column.label;
+  }
+  if (typeof column?.title === 'string') {
+    return column.title;
+  }
+  const titleChildren = column?.title?.props?.children;
+  if (typeof titleChildren === 'string') {
+    return titleChildren;
+  }
+  return fallbackKey;
+};
+
+/**
  * Assembles column data into various forms needed
  * @param {Object} columns - Object with column sort params as keys and column objects as values. Column objects must have a title key
  * @returns {Array} - an array of column sort params, sorted by weight, and a map of keys to column names
@@ -29,7 +50,7 @@ export const getColumnHelpers = columns => {
   const columnNamesKeys = Object.keys(columns);
   const keysToColumnNames = {};
   columnNamesKeys.forEach(key => {
-    keysToColumnNames[key] = columns[key].title;
+    keysToColumnNames[key] = getColumnLabel(columns[key], key);
   });
   columnNamesKeys.sort((a, b) => {
     const columnBWeight = columns[b]?.weight;

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { getColumnLabel, getColumnHelpers } from './helpers';
+
+describe('getColumnLabel', () => {
+  test('uses a string title', () => {
+    expect(getColumnLabel({ title: 'Type' }, 'bootc_booted_image')).toBe(
+      'Type'
+    );
+  });
+
+  test('prefers an explicit label over title', () => {
+    expect(
+      getColumnLabel({ title: 'Wrong', label: 'Type' }, 'bootc_booted_image')
+    ).toBe('Type');
+  });
+
+  test('extracts string children from a React title node', () => {
+    expect(
+      getColumnLabel(
+        { title: <span title="Image mode / package mode">Type</span> },
+        'bootc_booted_image'
+      )
+    ).toBe('Type');
+  });
+
+  test('falls back to the column key when title is a non-string without text children', () => {
+    expect(getColumnLabel({ title: <span /> }, 'bootc_booted_image')).toBe(
+      'bootc_booted_image'
+    );
+  });
+});
+
+
+describe('getColumnHelpers', () => {
+  test('maps keys to string labels even when title is a React node', () => {
+    const columns = {
+      bootc_booted_image: {
+        title: <span>Type</span>,
+        weight: 1,
+      },
+      name: {
+        title: 'Name',
+        weight: 2,
+      },
+    };
+    const [keys, labels] = getColumnHelpers(columns);
+    expect(keys).toEqual(['bootc_booted_image', 'name']);
+    expect(labels.bootc_booted_image).toBe('Type');
+    expect(labels.name).toBe('Name');
+    expect(typeof labels.bootc_booted_image).toBe('string');
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -42,7 +42,8 @@ A page component that displays a table with data fetched from the API. It provid
 @param {Object} {breadcrumbOptions} - props to send to the breadcrumb bar
 @param {React.ReactNode} {children} - optional children to be rendered inside the page instead of the table
 @param {Object}{columns} - Not needed when passing children. An object of objects representing the columns to be displayed in the table, keys should be the same as in the api response
-@param {string} columns[].title - the title of the column, translated
+@param {string} columns[].title - the title of the column, translated. Must be a string (or set columns[].label) so data-label/aria-label do not become "[object Object]".
+@param {string} columns[].label - optional accessible name when title is not a string (for example a custom header node).
 @param {function} columns[].wrapper - a function that returns a React component to be rendered in the column
 @param {boolean} columns[].isSorted - whether or not the column is sortable by its columnName. Only works if ORDER BY <columnName> will work.
 @param {function} columns[].isRelevant - optional function that takes in ForemanContext and returns a boolean. The column will be hidden from the column selector if isRelevant returns false. If the isRelevant key is omitted, columns are always relevant.


### PR DESCRIPTION
Katello’s Type column on All Hosts uses a React node as `title`. That node was passed into HTML attributes (`data-label`, header `aria-label`, sort keys, and the column selector). When the Type header wrapped, or when the table stacked, PatternFly rendered `[object Object]`.

`getColumnLabel()` now always returns a string: an optional `label`, a string `title`, text children of a React title, or the column key. The Type header can still render Katello’s custom header; only the accessible/string label is `Type`.

Plugin docs now say `title` must be a translated string. Use optional `label` if the header node is custom.

## Prerequisites for testing

- Foreman devel with Katello (All Hosts Type column)
- A host visible in All Hosts (a long name helps wrapping)

## How to test

1. Open **Hosts → All Hosts**.
2. Enable the **Type** column.
3. Shrink the window or add columns until the Type header wraps, or the table stacks.
4. The Type label should be **Type**, not `[object Object]`.
5. Optional: inspect a Type cell; `data-label` should be `Type`.
6. Confirm the Type header still shows the image-mode / package-mode UI.

## Screenshots

(Attach before: `[object Object]` on wrapped/stacked Type. After: `Type`.)