### PR TITLE
Fixes #39393 - Configure chrony on Ubuntu 26

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/ntp.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ntp.erb
@@ -20,7 +20,7 @@ ntp_server = host_param('ntp-server')
 echo "Updating system time"
 <% if os_family == 'Debian' -%>
   <% if ntp_server -%>
-    <% if @host.operatingsystem.name == "Ubuntu" -%>
+    <% if @host.operatingsystem.name == 'Ubuntu' && os_major < 26 -%>
       <%- if ntp_server.respond_to?(:join) -%>
       sed -i -E 's/^[[:space:]]*#?\s*NTP=.*/NTP=<%= ntp_server.first %>/' /etc/systemd/timesyncd.conf
       <%- else -%>

--- a/test/unit/foreman/templates/snippets/ntp_test.rb
+++ b/test/unit/foreman/templates/snippets/ntp_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class NtpSnippetTest < ActiveSupport::TestCase
+  def renderer
+    @renderer ||= Foreman::Renderer::SafeModeRenderer
+  end
+
+  def render_template(host)
+    @snippet ||= Rails.root.join('app', 'views', 'unattended', 'provisioning_templates', 'snippet', 'ntp.erb').read
+
+    source = OpenStruct.new(
+      name: 'ntp',
+      content: @snippet
+    )
+
+    scope = Foreman::Renderer::Scope::Provisioning.new(
+      host: host,
+      source: source
+    )
+
+    renderer.render(source, scope)
+  end
+
+  def ubuntu_host(major)
+    operating_system = FactoryBot.create(:ubuntu22_04, :with_associations, major: major.to_s)
+    host = FactoryBot.create(:host, :managed, :build => true, :operatingsystem => operating_system)
+    FactoryBot.create(:host_parameter, host: host, name: 'ntp-server', value: 'ntp.example.com')
+    host
+  end
+
+  setup do
+    disable_orchestration
+  end
+
+  test 'configures systemd-timesyncd before Ubuntu 26' do
+    result = render_template(ubuntu_host(24))
+
+    assert_includes result, 'systemctl enable --now systemd-timesyncd'
+    assert_includes result, 'timedatectl set-ntp true'
+    refute_includes result, 'apt-get install -y chrony'
+  end
+
+  test 'configures chrony on Ubuntu 26' do
+    result = render_template(ubuntu_host(26))
+
+    assert_includes result, 'apt-get install -y chrony'
+    assert_includes result, '/etc/chrony/chrony.conf'
+    assert_includes result, 'systemctl enable --now chrony'
+    refute_includes result, 'systemd-timesyncd'
+  end
+end


### PR DESCRIPTION
Fixes #39393

Ubuntu 26 uses chrony instead of systemd-timesyncd by default. Keep the existing systemd-timesyncd path for older Ubuntu releases and use the Debian chrony path for Ubuntu 26 and newer.

Testing prerequisites:
- None

Testing scenarios:
- Render the NTP snippet for Ubuntu 24 and verify systemd-timesyncd is enabled while chrony is not installed.
- Render it for Ubuntu 26 and verify chrony is installed, configured, and enabled while systemd-timesyncd is not used.

Verification:
- Targeted renderer tests pass on Ruby 3.3 with PostgreSQL 13.
- Full test:units passes: 5,664 tests and 14,093 assertions, with 0 failures and 0 errors.
- RuboCop reports no offenses in the added test.